### PR TITLE
APPSRE-5972 extract unwrapper logic

### DIFF
--- a/qenerate/core/unwrapper.py
+++ b/qenerate/core/unwrapper.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from enum import Enum
+from graphql import GraphQLOutputType, GraphQLNonNull, GraphQLList, GraphQLScalarType
+
+
+class WrapperType(Enum):
+    LIST = 1
+    OPTIONAL = 2
+
+
+@dataclass
+class UnwrapperResult:
+    wrapper_stack: list[WrapperType]
+    inner_gql_type: GraphQLOutputType
+    is_primitive: bool
+
+
+class Unwrapper:
+    """
+    GraphQLOutputType can be nested in lists and non-optionals.
+    Unwrapper is responsible for unwrapping those lists and
+    non-optionals.
+    """
+
+    @staticmethod
+    def unwrap(gql_type: GraphQLOutputType) -> UnwrapperResult:
+        wrappers: list[WrapperType] = []
+        if isinstance(gql_type, GraphQLNonNull):
+            gql_type = gql_type.of_type
+        else:
+            wrappers.append(WrapperType.OPTIONAL)
+
+        if isinstance(gql_type, GraphQLList):
+            res = Unwrapper.unwrap(gql_type.of_type)
+            wrappers.append(WrapperType.LIST)
+            wrappers.extend(res.wrapper_stack)
+            return UnwrapperResult(
+                wrapper_stack=wrappers,
+                inner_gql_type=res.inner_gql_type,
+                is_primitive=res.is_primitive,
+            )
+
+        return UnwrapperResult(
+            wrapper_stack=wrappers,
+            inner_gql_type=gql_type,
+            is_primitive=isinstance(gql_type, GraphQLScalarType),
+        )

--- a/tests/core/test_unwrapper.py
+++ b/tests/core/test_unwrapper.py
@@ -1,0 +1,61 @@
+import pytest
+
+from qenerate.core.unwrapper import Unwrapper, UnwrapperResult, WrapperType
+
+from graphql import (
+    GraphQLOutputType,
+    GraphQLScalarType,
+    GraphQLNonNull,
+    GraphQLList,
+    GraphQLObjectType,
+)
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        [
+            GraphQLScalarType(name="String"),
+            UnwrapperResult(
+                wrapper_stack=[WrapperType.OPTIONAL],
+                inner_gql_type=GraphQLScalarType(name="String"),
+                is_primitive=True,
+            ),
+        ],
+        [
+            GraphQLNonNull(GraphQLList(GraphQLObjectType(name="MyObject", fields=[]))),
+            UnwrapperResult(
+                wrapper_stack=[WrapperType.LIST, WrapperType.OPTIONAL],
+                inner_gql_type=GraphQLObjectType(name="MyObject", fields=[]),
+                is_primitive=False,
+            ),
+        ],
+        [
+            GraphQLList(GraphQLNonNull(GraphQLScalarType(name="Integer"))),
+            UnwrapperResult(
+                wrapper_stack=[WrapperType.OPTIONAL, WrapperType.LIST],
+                inner_gql_type=GraphQLScalarType(name="Integer"),
+                is_primitive=True,
+            ),
+        ],
+        [
+            GraphQLList(GraphQLNonNull(GraphQLList(GraphQLScalarType(name="Integer")))),
+            UnwrapperResult(
+                wrapper_stack=[
+                    WrapperType.OPTIONAL,
+                    WrapperType.LIST,
+                    WrapperType.LIST,
+                    WrapperType.OPTIONAL,
+                ],
+                inner_gql_type=GraphQLScalarType(name="Integer"),
+                is_primitive=True,
+            ),
+        ],
+    ],
+)
+def test_unwrapper(input: GraphQLOutputType, expected: UnwrapperResult):
+    result = Unwrapper.unwrap(input)
+
+    assert result.is_primitive == expected.is_primitive
+    assert result.wrapper_stack == expected.wrapper_stack
+    assert result.inner_gql_type.name == expected.inner_gql_type.name


### PR DESCRIPTION
This is a first step in reducing the logic inside the Visitor.

The type unwrapping logic should apply across all plugins, thus it can be moved to `core`.