### PR TITLE
APPSRE-5972 add preprocessor

### DIFF
--- a/qenerate/core/plugin.py
+++ b/qenerate/core/plugin.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from typing import Any
 from pathlib import Path
 
+from qenerate.core.preprocessor import GQLDefinition
+
 
 @dataclass(eq=True, order=True)
 class GeneratedFile:
@@ -18,7 +20,7 @@ class GeneratedFile:
 
 class Plugin:
     def generate(
-        self, query_file: str, raw_schema: dict[Any, Any]
+        self, definition: GQLDefinition, raw_schema: dict[Any, Any]
     ) -> list[GeneratedFile]:
         raise NotImplementedError
 

--- a/qenerate/core/preprocessor.py
+++ b/qenerate/core/preprocessor.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+from graphql import parse, visit, Visitor, OperationDefinitionNode, OperationType
+
+from qenerate.core.feature_flag_parser import FeatureFlagParser, FeatureFlags
+
+
+class GQLDefinitionType(Enum):
+    QUERY = 1
+
+
+@dataclass
+class GQLDefinition:
+    feature_flags: FeatureFlags
+    source_file: Path
+    kind: GQLDefinitionType
+    definition: str
+    name: str
+
+
+class DefinitionVisitor(Visitor):
+    def __init__(self, source_file_path: Path, feature_flags: FeatureFlags):
+        Visitor.__init__(self)
+        self.definitions: list[GQLDefinition] = []
+        self._feature_flags = feature_flags
+        self._source_file_path = source_file_path
+        self._current: Optional[GQLDefinition] = None
+
+    def enter_operation_definition(self, node: OperationDefinitionNode, *_):
+        if not node.loc:
+            # TODO: proper error
+            raise ValueError(f"{node} does not have loc set")
+
+        if not node.name:
+            # TODO: proper error
+            raise ValueError(f"{node} does not have a name")
+        start = node.loc.start_token.start
+        end = node.loc.end_token.end
+        body = node.loc.source.body[start:end]
+
+        if node.operation != OperationType.QUERY:
+            # TODO: logger
+            # TODO: raise
+            print(
+                "[WARNING] Skipping operation definition because"
+                f" it is not a query: \n{body}"
+            )
+            return
+
+        definition = GQLDefinition(
+            kind=GQLDefinitionType.QUERY,
+            definition=body,
+            source_file=self._source_file_path,
+            feature_flags=self._feature_flags,
+            name=node.name.value,
+        )
+        self._current = definition
+
+    def leave_operation_definition(self, *_):
+        if self._current:
+            self.definitions.append(self._current)
+        self._current = None
+
+
+class Preprocessor:
+    def process_file(self, file_path: Path) -> list[GQLDefinition]:
+        with open(file_path, "r") as f:
+            content = f.read()
+        feature_flags = FeatureFlagParser.parse(
+            query=content,
+        )
+        document_ast = parse(content)
+        visitor = DefinitionVisitor(
+            feature_flags=feature_flags,
+            source_file_path=file_path,
+        )
+        visit(document_ast, visitor)
+        return visitor.definitions

--- a/tests/core/preprocessor/queries/multiple_queries.gql
+++ b/tests/core/preprocessor/queries/multiple_queries.gql
@@ -1,0 +1,12 @@
+# qenerate: plugin=test
+query FirstQuery {
+    some {
+        name
+    }
+}
+
+query SecondQuery {
+    other {
+        name
+    }
+}

--- a/tests/core/preprocessor/queries/mutation.gql
+++ b/tests/core/preprocessor/queries/mutation.gql
@@ -1,0 +1,8 @@
+# qenerate: plugin=test
+# This should be ignored by qenerate
+mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {
+  createReview(episode: $ep, review: $review) {
+    stars
+    commentary
+  }
+}

--- a/tests/core/preprocessor/queries/single_query.gql
+++ b/tests/core/preprocessor/queries/single_query.gql
@@ -1,0 +1,6 @@
+# qenerate: plugin=test
+query MyQuery {
+    some {
+        name
+    }
+}

--- a/tests/core/test_code_command.py
+++ b/tests/core/test_code_command.py
@@ -5,20 +5,28 @@ from typing import Any
 from qenerate.core.plugin import Plugin, GeneratedFile
 from qenerate.core.code_command import CodeCommand
 from qenerate.core.code_command import plugins
+from qenerate.core.preprocessor import GQLDefinition
 
 
 class FakePlugin(Plugin):
     def generate(
-        self, query_file: str, raw_schema: dict[Any, Any]
+        self, definition: GQLDefinition, raw_schema: dict[Any, Any]
     ) -> list[GeneratedFile]:
-        return [GeneratedFile(file=Path(query_file).with_suffix(".py"), content="fake")]
+        return [
+            GeneratedFile(
+                file=Path(definition.source_file).with_suffix(".py"), content="fake"
+            )
+        ]
 
 
 def test_single_file(fs):
     fs.add_real_directory("tests/queries")
     fs.create_file(
         "/tmp/my_query.gql",
-        contents="# qenerate: plugin=fake",
+        contents="""
+        # qenerate: plugin=fake
+        query MyQuery { some }
+        """,
     )
 
     plugins["fake"] = FakePlugin()
@@ -35,7 +43,10 @@ def test_single_file_no_plugin_flag(fs):
     fs.add_real_directory("tests/queries")
     fs.create_file(
         "/tmp/my_query.gql",
-        contents="# qenerate",
+        contents="""
+        # qenerate
+        query MyQuery { some }
+        """,
     )
 
     plugins["fake"] = FakePlugin()
@@ -52,7 +63,10 @@ def test_unknown_plugin_flag(fs):
     fs.add_real_directory("tests/queries")
     fs.create_file(
         "/tmp/my_query.gql",
-        contents="# qenerate: plugin=does_not_exist",
+        contents="""
+        # qenerate: plugin=does_not_exist
+        query MyQuery { some }
+        """,
     )
 
     plugins["fake"] = FakePlugin()
@@ -69,15 +83,24 @@ def test_dir_tree(fs):
     fs.add_real_directory("tests/queries")
     fs.create_file(
         "/tmp/my_query.gql",
-        contents="# qenerate: plugin=fake",
+        contents="""
+        # qenerate: plugin=fake
+        query MyQuery { some }
+        """,
     )
     fs.create_file(
         "/tmp/sub/my_query.gql",
-        contents="# qenerate: plugin=fake",
+        contents="""
+        # qenerate: plugin=fake
+        query MyQuery { some }
+        """,
     )
     fs.create_file(
         "/tmp/sub/my_query2.gql",
-        contents="# qenerate: plugin=fake",
+        contents="""
+        # qenerate: plugin=fake
+        query MyQuery { some }
+        """,
     )
 
     plugins["fake"] = FakePlugin()

--- a/tests/core/test_preprocessor.py
+++ b/tests/core/test_preprocessor.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from typing import Iterable
+import pytest
+
+from qenerate.core.preprocessor import GQLDefinition, GQLDefinitionType, Preprocessor
+from qenerate.core.feature_flag_parser import FeatureFlags
+
+
+def normalize_definition(definition: str) -> str:
+    return " ".join(definition.split())
+
+
+@pytest.mark.parametrize(
+    "file, expected",
+    [
+        # Test a file with a single query
+        [
+            Path("tests/core/preprocessor/queries/single_query.gql"),
+            [
+                GQLDefinition(
+                    feature_flags=FeatureFlags(plugin="test"),
+                    kind=GQLDefinitionType.QUERY,
+                    name="MyQuery",
+                    definition="query MyQuery { some { name } }",
+                    source_file="",  # adjusted in test
+                ),
+            ],
+        ],
+        # Test a file containing multiple queries
+        [
+            Path("tests/core/preprocessor/queries/multiple_queries.gql"),
+            [
+                GQLDefinition(
+                    feature_flags=FeatureFlags(plugin="test"),
+                    kind=GQLDefinitionType.QUERY,
+                    name="FirstQuery",
+                    definition="query FirstQuery { some { name } }",
+                    source_file="",  # adjusted in test
+                ),
+                GQLDefinition(
+                    feature_flags=FeatureFlags(plugin="test"),
+                    kind=GQLDefinitionType.QUERY,
+                    name="SecondQuery",
+                    definition="query SecondQuery { other { name } }",
+                    source_file="",  # adjusted in test
+                ),
+            ],
+        ],
+        # Test a file containing a mutation
+        [
+            Path("tests/core/preprocessor/queries/mutation.gql"),
+            [],
+        ],
+    ],
+)
+def test_preprocessor(file: Path, expected: Iterable[GQLDefinition]):
+    for ex in expected:
+        ex.source_file = file
+
+    preprocessor = Preprocessor()
+    definitions = preprocessor.process_file(file)
+    for definition in definitions:
+        definition.definition = normalize_definition(definition.definition)
+
+    assert definitions == expected


### PR DESCRIPTION
Adding a preprocessor which parses `.gql` files and converts them to `GQLDefinition` files, which contain all meta necessary for further processing.

Preprocessor logic will be required for fragment support.