### PR TITLE
APPSRE-5972 allow unused

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qenerate"
-version = "0.2.1"
+version = "0.2.2"
 description = "Code Generator for GraphQL Query Data Classes"
 authors = [
     "Red Hat - Service Delivery - AppSRE <sd-app-sre@redhat.com>"

--- a/qenerate/core/preprocessor.py
+++ b/qenerate/core/preprocessor.py
@@ -136,6 +136,8 @@ class Preprocessor:
 
         errors = validate(schema, document_ast)
         for error in errors:
+            if "Fragment" in error.message and "is never used" in error.message:
+                continue
             raise error
 
     def process_file(self, file_path: Path) -> list[GQLDefinition]:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ entry_points = {"console_scripts": ["qenerate = qenerate.cli:run"]}
 
 setup_kwargs = {
     "name": "qenerate",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "Code Generator for GraphQL Query Data Classes",
     "long_description": None,
     "author": "Service Delivery - AppSRE",

--- a/tests/core/test_preprocessor.py
+++ b/tests/core/test_preprocessor.py
@@ -198,11 +198,11 @@ def test_preprocessor(file: Path, expected: Iterable[GQLDefinition]):
             None,
         ],
         [
-            # Unused fragment
+            # Unused fragment - allow it
             [
                 "fragment MyFragment on User_v1 { name }",
             ],
-            GraphQLError,
+            None,
         ],
         [
             # Unknown fragment


### PR DESCRIPTION
A user should be able to define fragments, even if they are not being used yet.