### PR TITLE
#67 map str as default for scalars

### DIFF
--- a/docs/plugins/pydantic_v1.md
+++ b/docs/plugins/pydantic_v1.md
@@ -10,6 +10,18 @@ Supported definitions are:
 - `fragment`
 - `query`
 
+## Opinionated Custom Scalars
+
+The `pydantic_v1` plugin has an opinionated approach towards some very common custom scalars
+defined in https://the-guild.dev/graphql/scalars/docs
+
+Currently it maps the following: 
+
+- `JSON` maps to `pydantic.Json`
+- `DateTime` maps to `datetime.datetime` 
+
+Any other custom scalar will be mapped to `str`.
+
 ## Examples
 
 ### Query with inline fragments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qenerate"
-version = "0.4.6"
+version = "0.4.7"
 description = "Code Generator for GraphQL Query and Fragment Data Classes"
 authors = [
     "Red Hat - Service Delivery - AppSRE <sd-app-sre@redhat.com>"

--- a/qenerate/plugins/pydantic_v1/mapper.py
+++ b/qenerate/plugins/pydantic_v1/mapper.py
@@ -42,7 +42,7 @@ def graphql_primitive_to_python(graphql_type: GraphQLOutputType) -> str:
         "DateTime": "datetime",
         "JSON": "Json",
     }
-    return mapping.get(str(graphql_type), str(graphql_type))
+    return mapping.get(str(graphql_type), "str")
 
 
 def graphql_field_name_to_python(name: str) -> str:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ entry_points = {"console_scripts": ["qenerate = qenerate.cli:run"]}
 
 setup_kwargs = {
     "name": "qenerate",
-    "version": "0.4.6",
+    "version": "0.4.7",
     "description": "Code Generator for GraphQL Query and Fragment Data Classes",
     "long_description": "Qenerate is a Code Generator for GraphQL Query and Fragment Data Classes. Documentation is at https://github.com/app-sre/qenerate .",
     "author": "Service Delivery - AppSRE",

--- a/tests/generator/definitions/github/issues_datetime_html.gql
+++ b/tests/generator/definitions/github/issues_datetime_html.gql
@@ -3,6 +3,7 @@ query IssuesDate {
     issues(first: 10) {
       nodes {
         createdAt
+        bodyHTML
       }
     }
   }

--- a/tests/generator/expected/pydantic_v1/github/issues_datetime_html.py.txt
+++ b/tests/generator/expected/pydantic_v1/github/issues_datetime_html.py.txt
@@ -24,6 +24,7 @@ query IssuesDate {
     issues(first: 10) {
       nodes {
         createdAt
+        bodyHTML
       }
     }
   }
@@ -34,6 +35,7 @@ query IssuesDate {
 
 class Issue(BaseModel):
     created_at: datetime = Field(..., alias="createdAt")
+    body_html: str = Field(..., alias="bodyHTML")
 
     class Config:
         smart_union = True

--- a/tests/plugins/test_generate.py
+++ b/tests/plugins/test_generate.py
@@ -92,7 +92,7 @@ class Schema(Enum):
             {},
             {
                 "invitations_enum": GQLDefinitionType.QUERY,
-                "issues_datetime": GQLDefinitionType.QUERY,
+                "issues_datetime_html": GQLDefinitionType.QUERY,
             },
             {},
             Schema.GITHUB,


### PR DESCRIPTION
We should map unknown custom scalars to `str`.
Further, the documentation should highlight that `pydantic_v1` is opinionated towards supporting common custom scalars defined in https://the-guild.dev/graphql/scalars/docs

fixes #67 