### PR TITLE
Update Optional field to be not required

### DIFF
--- a/demo/gql/fragments/fragment1.py
+++ b/demo/gql/fragments/fragment1.py
@@ -27,5 +27,5 @@ class ConfiguredBaseModel(BaseModel):
 class VaultSecret(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")

--- a/demo/gql/queries/example1.py
+++ b/demo/gql/queries/example1.py
@@ -49,11 +49,11 @@ class ResourceV1(ConfiguredBaseModel):
 
 class JenkinsConfigV1_JenkinsConfigV1(JenkinsConfigV1):
     q_type: str = Field(..., alias="type")
-    config_path: Optional[ResourceV1] = Field(..., alias="config_path")
+    config_path: Optional[ResourceV1] = Field(alias="config_path")
 
 
 class JenkinsConfigsQueryData(ConfiguredBaseModel):
-    jenkins_configs: Optional[list[Union[JenkinsConfigV1_JenkinsConfigV1, JenkinsConfigV1]]] = Field(..., alias="jenkins_configs")
+    jenkins_configs: Optional[list[Union[JenkinsConfigV1_JenkinsConfigV1, JenkinsConfigV1]]] = Field(alias="jenkins_configs")
 
 
 def query(query_func: Callable, **kwargs: Any) -> JenkinsConfigsQueryData:

--- a/demo/gql/queries/example2.py
+++ b/demo/gql/queries/example2.py
@@ -52,7 +52,7 @@ class GitlabInstanceV1(ConfiguredBaseModel):
 
 
 class GitlabInstanceQueryData(ConfiguredBaseModel):
-    instances: Optional[list[GitlabInstanceV1]] = Field(..., alias="instances")
+    instances: Optional[list[GitlabInstanceV1]] = Field(alias="instances")
 
 
 def query(query_func: Callable, **kwargs: Any) -> GitlabInstanceQueryData:

--- a/qenerate/plugins/pydantic_v1/typed_ast.py
+++ b/qenerate/plugins/pydantic_v1/typed_ast.py
@@ -9,6 +9,16 @@ BASE_CLASS_NAME = "ConfiguredBaseModel"
 INDENT = "    "
 
 
+def _build_field_code_string(field: ParsedClassNode) -> str:
+    field_arg = (
+        "" if field.parsed_type.is_optional or field.parsed_type.enum_map else "..., "
+    )
+    return (
+        f"{INDENT}{field.py_key}: {field.field_type()} = "
+        f'Field({field_arg}alias="{field.gql_key}")'
+    )
+
+
 @dataclass
 class ParsedNode:
     parent: Optional[ParsedNode]
@@ -54,12 +64,7 @@ class ParsedInlineFragmentNode(ParsedNode):
         fields_added = False
         for field in self.fields:
             if isinstance(field, ParsedClassNode):
-                lines.append(
-                    (
-                        f"{INDENT}{field.py_key}: {field.field_type()} = "
-                        f'Field(..., alias="{field.gql_key}")'
-                    )
-                )
+                lines.append(_build_field_code_string(field))
                 fields_added = True
 
         if not fields_added:
@@ -88,16 +93,8 @@ class ParsedClassNode(ParsedNode):
         lines.append(f"class {self.parsed_type.unwrapped_python_type}({base_classes}):")
         fields_added = False
         for field in self.fields:
-            field_arg = "..., "
-            if field.parsed_type.enum_map:
-                field_arg = ""
             if isinstance(field, ParsedClassNode):
-                lines.append(
-                    (
-                        f"{INDENT}{field.py_key}: {field.field_type()} = "
-                        f'Field({field_arg}alias="{field.gql_key}")'
-                    )
-                )
+                lines.append(_build_field_code_string(field))
                 fields_added = True
 
         if not fields_added:
@@ -170,12 +167,7 @@ class ParsedOperationNode(ParsedNode):
         fields_added = False
         for field in self.fields:
             if isinstance(field, ParsedClassNode):
-                lines.append(
-                    (
-                        f"{INDENT}{field.py_key}: {field.field_type()} = "
-                        f'Field(..., alias="{field.gql_key}")'
-                    )
-                )
+                lines.append(_build_field_code_string(field))
                 fields_added = True
 
         if not fields_added:
@@ -195,12 +187,7 @@ class ParsedFragmentDefinitionNode(ParsedNode):
         fields_added = False
         for field in self.fields:
             if isinstance(field, ParsedClassNode):
-                lines.append(
-                    (
-                        f"{INDENT}{field.py_key}: {field.field_type()} = "
-                        f'Field(..., alias="{field.gql_key}")'
-                    )
-                )
+                lines.append(_build_field_code_string(field))
                 fields_added = True
 
         if not fields_added:
@@ -220,4 +207,5 @@ class ParsedFieldType:
     unwrapped_python_type: str
     wrapped_python_type: str
     is_primitive: bool
+    is_optional: bool
     enum_map: dict[str, Any]

--- a/tests/generator/expected/pydantic_v1/complex_queries/enumerate_collisions.py.txt
+++ b/tests/generator/expected/pydantic_v1/complex_queries/enumerate_collisions.py.txt
@@ -75,8 +75,8 @@ class ClusterSpecV1__2(ConfiguredBaseModel):
 
 class ClusterV1__2(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    spec: Optional[ClusterSpecV1__2] = Field(..., alias="spec")
-    internal: Optional[bool] = Field(..., alias="internal")
+    spec: Optional[ClusterSpecV1__2] = Field(alias="spec")
+    internal: Optional[bool] = Field(alias="internal")
 
 
 class ClusterPeeringConnectionClusterRequesterV1(ClusterPeeringConnectionV1):
@@ -89,8 +89,8 @@ class ClusterSpecV1__3(ConfiguredBaseModel):
 
 class ClusterV1__3(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    spec: Optional[ClusterSpecV1__3] = Field(..., alias="spec")
-    internal: Optional[bool] = Field(..., alias="internal")
+    spec: Optional[ClusterSpecV1__3] = Field(alias="spec")
+    internal: Optional[bool] = Field(alias="internal")
 
 
 class ClusterPeeringConnectionClusterAccepterV1(ClusterPeeringConnectionV1):
@@ -98,18 +98,18 @@ class ClusterPeeringConnectionClusterAccepterV1(ClusterPeeringConnectionV1):
 
 
 class ClusterPeeringV1(ConfiguredBaseModel):
-    connections: Optional[list[Union[ClusterPeeringConnectionClusterRequesterV1, ClusterPeeringConnectionClusterAccepterV1, ClusterPeeringConnectionV1]]] = Field(..., alias="connections")
+    connections: Optional[list[Union[ClusterPeeringConnectionClusterRequesterV1, ClusterPeeringConnectionClusterAccepterV1, ClusterPeeringConnectionV1]]] = Field(alias="connections")
 
 
 class ClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    spec: Optional[ClusterSpecV1] = Field(..., alias="spec")
-    internal: Optional[bool] = Field(..., alias="internal")
-    peering: Optional[ClusterPeeringV1] = Field(..., alias="peering")
+    spec: Optional[ClusterSpecV1] = Field(alias="spec")
+    internal: Optional[bool] = Field(alias="internal")
+    peering: Optional[ClusterPeeringV1] = Field(alias="peering")
 
 
 class EnumerateCollisionsQueryData(ConfiguredBaseModel):
-    clusters: Optional[list[Optional[ClusterV1]]] = Field(..., alias="clusters")
+    clusters: Optional[list[Optional[ClusterV1]]] = Field(alias="clusters")
 
 
 def query(query_func: Callable, **kwargs: Any) -> EnumerateCollisionsQueryData:

--- a/tests/generator/expected/pydantic_v1/complex_queries/ocp_with_inline_fragments.py.txt
+++ b/tests/generator/expected/pydantic_v1/complex_queries/ocp_with_inline_fragments.py.txt
@@ -58,7 +58,7 @@ class ClusterAuthGithubOrgTeamV1(ClusterAuthV1):
 
 
 class ClusterV1(ConfiguredBaseModel):
-    auth: Optional[Union[ClusterAuthGithubOrgTeamV1, ClusterAuthGithubOrgV1, ClusterAuthV1]] = Field(..., alias="auth")
+    auth: Optional[Union[ClusterAuthGithubOrgTeamV1, ClusterAuthGithubOrgV1, ClusterAuthV1]] = Field(alias="auth")
 
 
 class OcpReleaseMirrorV1(ConfiguredBaseModel):
@@ -66,7 +66,7 @@ class OcpReleaseMirrorV1(ConfiguredBaseModel):
 
 
 class OCPWithInterfaceQueryData(ConfiguredBaseModel):
-    ocp_release_mirror: Optional[list[Optional[OcpReleaseMirrorV1]]] = Field(..., alias="ocp_release_mirror")
+    ocp_release_mirror: Optional[list[Optional[OcpReleaseMirrorV1]]] = Field(alias="ocp_release_mirror")
 
 
 def query(query_func: Callable, **kwargs: Any) -> OCPWithInterfaceQueryData:

--- a/tests/generator/expected/pydantic_v1/complex_queries/saas_humongous.py.txt
+++ b/tests/generator/expected/pydantic_v1/complex_queries/saas_humongous.py.txt
@@ -274,38 +274,38 @@ class PipelinesProviderV1(ConfiguredBaseModel):
 class VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class ClusterJumpHostV1(ConfiguredBaseModel):
     hostname: str = Field(..., alias="hostname")
     known_hosts: str = Field(..., alias="knownHosts")
     user: str = Field(..., alias="user")
-    port: Optional[int] = Field(..., alias="port")
+    port: Optional[int] = Field(alias="port")
     identity: VaultSecretV1 = Field(..., alias="identity")
 
 
 class ClusterV1_VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class DisableClusterAutomationsV1(ConfiguredBaseModel):
-    integrations: Optional[list[Optional[str]]] = Field(..., alias="integrations")
+    integrations: Optional[list[Optional[str]]] = Field(alias="integrations")
 
 
 class ClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     console_url: str = Field(..., alias="consoleUrl")
     server_url: str = Field(..., alias="serverUrl")
-    insecure_skip_tls_verify: Optional[bool] = Field(..., alias="insecureSkipTLSVerify")
-    jump_host: Optional[ClusterJumpHostV1] = Field(..., alias="jumpHost")
-    automation_token: Optional[ClusterV1_VaultSecretV1] = Field(..., alias="automationToken")
-    internal: Optional[bool] = Field(..., alias="internal")
-    disable: Optional[DisableClusterAutomationsV1] = Field(..., alias="disable")
+    insecure_skip_tls_verify: Optional[bool] = Field(alias="insecureSkipTLSVerify")
+    jump_host: Optional[ClusterJumpHostV1] = Field(alias="jumpHost")
+    automation_token: Optional[ClusterV1_VaultSecretV1] = Field(alias="automationToken")
+    internal: Optional[bool] = Field(alias="internal")
+    disable: Optional[DisableClusterAutomationsV1] = Field(alias="disable")
 
 
 class NamespaceV1(ConfiguredBaseModel):
@@ -336,7 +336,7 @@ class PipelinesProviderTektonV1_PipelinesProviderPipelineTemplatesV1(ConfiguredB
 class PipelinesProviderTektonV1(PipelinesProviderV1):
     namespace: NamespaceV1 = Field(..., alias="namespace")
     defaults: PipelinesProviderTektonProviderDefaultsV1 = Field(..., alias="defaults")
-    pipeline_templates: Optional[PipelinesProviderTektonV1_PipelinesProviderPipelineTemplatesV1] = Field(..., alias="pipelineTemplates")
+    pipeline_templates: Optional[PipelinesProviderTektonV1_PipelinesProviderPipelineTemplatesV1] = Field(alias="pipelineTemplates")
 
 
 class ResourceRequirementsV1(ConfiguredBaseModel):
@@ -357,8 +357,8 @@ class DeployResourcesV1(ConfiguredBaseModel):
 class SlackWorkspaceIntegrationV1_VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class SlackWorkspaceIntegrationV1(ConfiguredBaseModel):
@@ -371,44 +371,44 @@ class SlackWorkspaceIntegrationV1(ConfiguredBaseModel):
 
 class SlackWorkspaceV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    integrations: Optional[list[Optional[SlackWorkspaceIntegrationV1]]] = Field(..., alias="integrations")
+    integrations: Optional[list[Optional[SlackWorkspaceIntegrationV1]]] = Field(alias="integrations")
 
 
 class SlackOutputNotificationsV1(ConfiguredBaseModel):
-    start: Optional[bool] = Field(..., alias="start")
+    start: Optional[bool] = Field(alias="start")
 
 
 class SlackOutputV1(ConfiguredBaseModel):
-    output: Optional[str] = Field(..., alias="output")
+    output: Optional[str] = Field(alias="output")
     workspace: SlackWorkspaceV1 = Field(..., alias="workspace")
-    channel: Optional[str] = Field(..., alias="channel")
-    notifications: Optional[SlackOutputNotificationsV1] = Field(..., alias="notifications")
+    channel: Optional[str] = Field(alias="channel")
+    notifications: Optional[SlackOutputNotificationsV1] = Field(alias="notifications")
 
 
 class SaasFileAuthenticationV1_VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class SaasFileV2_SaasFileAuthenticationV1_VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class SaasFileAuthenticationV1(ConfiguredBaseModel):
-    code: Optional[SaasFileAuthenticationV1_VaultSecretV1] = Field(..., alias="code")
-    image: Optional[SaasFileV2_SaasFileAuthenticationV1_VaultSecretV1] = Field(..., alias="image")
+    code: Optional[SaasFileAuthenticationV1_VaultSecretV1] = Field(alias="code")
+    image: Optional[SaasFileV2_SaasFileAuthenticationV1_VaultSecretV1] = Field(alias="image")
 
 
 class SaasSecretParametersV1_VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class SaasSecretParametersV1(ConfiguredBaseModel):
@@ -419,8 +419,8 @@ class SaasSecretParametersV1(ConfiguredBaseModel):
 class SaasResourceTemplateV2_SaasSecretParametersV1_VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class SaasResourceTemplateV2_SaasSecretParametersV1(ConfiguredBaseModel):
@@ -431,8 +431,8 @@ class SaasResourceTemplateV2_SaasSecretParametersV1(ConfiguredBaseModel):
 class EnvironmentV1_SaasSecretParametersV1_VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class EnvironmentV1_SaasSecretParametersV1(ConfiguredBaseModel):
@@ -442,8 +442,8 @@ class EnvironmentV1_SaasSecretParametersV1(ConfiguredBaseModel):
 
 class EnvironmentV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    parameters: Optional[Json] = Field(..., alias="parameters")
-    secret_parameters: Optional[list[Optional[EnvironmentV1_SaasSecretParametersV1]]] = Field(..., alias="secretParameters")
+    parameters: Optional[Json] = Field(alias="parameters")
+    secret_parameters: Optional[list[Optional[EnvironmentV1_SaasSecretParametersV1]]] = Field(alias="secretParameters")
 
 
 class SaasResourceTemplateTargetV2_NamespaceV1_AppV1(ConfiguredBaseModel):
@@ -453,45 +453,45 @@ class SaasResourceTemplateTargetV2_NamespaceV1_AppV1(ConfiguredBaseModel):
 class SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_ClusterJumpHostV1_VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_ClusterJumpHostV1(ConfiguredBaseModel):
     hostname: str = Field(..., alias="hostname")
     known_hosts: str = Field(..., alias="knownHosts")
     user: str = Field(..., alias="user")
-    port: Optional[int] = Field(..., alias="port")
+    port: Optional[int] = Field(alias="port")
     identity: SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_ClusterJumpHostV1_VaultSecretV1 = Field(..., alias="identity")
 
 
 class SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class SaasResourceTemplateTargetV2_NamespaceV1_SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_DisableClusterAutomationsV1(ConfiguredBaseModel):
-    integrations: Optional[list[Optional[str]]] = Field(..., alias="integrations")
+    integrations: Optional[list[Optional[str]]] = Field(alias="integrations")
 
 
 class SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     server_url: str = Field(..., alias="serverUrl")
-    insecure_skip_tls_verify: Optional[bool] = Field(..., alias="insecureSkipTLSVerify")
-    jump_host: Optional[SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_ClusterJumpHostV1] = Field(..., alias="jumpHost")
-    automation_token: Optional[SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_VaultSecretV1] = Field(..., alias="automationToken")
-    cluster_admin_automation_token: Optional[SaasResourceTemplateTargetV2_NamespaceV1_SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_VaultSecretV1] = Field(..., alias="clusterAdminAutomationToken")
-    internal: Optional[bool] = Field(..., alias="internal")
-    disable: Optional[SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_DisableClusterAutomationsV1] = Field(..., alias="disable")
+    insecure_skip_tls_verify: Optional[bool] = Field(alias="insecureSkipTLSVerify")
+    jump_host: Optional[SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_ClusterJumpHostV1] = Field(alias="jumpHost")
+    automation_token: Optional[SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_VaultSecretV1] = Field(alias="automationToken")
+    cluster_admin_automation_token: Optional[SaasResourceTemplateTargetV2_NamespaceV1_SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_VaultSecretV1] = Field(alias="clusterAdminAutomationToken")
+    internal: Optional[bool] = Field(alias="internal")
+    disable: Optional[SaasResourceTemplateTargetV2_NamespaceV1_ClusterV1_DisableClusterAutomationsV1] = Field(alias="disable")
 
 
 class SaasResourceTemplateTargetV2_NamespaceV1(ConfiguredBaseModel):
@@ -506,27 +506,27 @@ class PromotionChannelDataV1(ConfiguredBaseModel):
 
 
 class ParentSaasPromotionV1(PromotionChannelDataV1):
-    parent_saas: Optional[str] = Field(..., alias="parent_saas")
-    target_config_hash: Optional[str] = Field(..., alias="target_config_hash")
+    parent_saas: Optional[str] = Field(alias="parent_saas")
+    target_config_hash: Optional[str] = Field(alias="target_config_hash")
 
 
 class PromotionDataV1(ConfiguredBaseModel):
-    channel: Optional[str] = Field(..., alias="channel")
-    data: Optional[list[Optional[Union[ParentSaasPromotionV1, PromotionChannelDataV1]]]] = Field(..., alias="data")
+    channel: Optional[str] = Field(alias="channel")
+    data: Optional[list[Optional[Union[ParentSaasPromotionV1, PromotionChannelDataV1]]]] = Field(alias="data")
 
 
 class SaasResourceTemplateTargetPromotionV1(ConfiguredBaseModel):
-    auto: Optional[bool] = Field(..., alias="auto")
-    publish: Optional[list[Optional[str]]] = Field(..., alias="publish")
-    subscribe: Optional[list[Optional[str]]] = Field(..., alias="subscribe")
-    promotion_data: Optional[list[Optional[PromotionDataV1]]] = Field(..., alias="promotion_data")
+    auto: Optional[bool] = Field(alias="auto")
+    publish: Optional[list[Optional[str]]] = Field(alias="publish")
+    subscribe: Optional[list[Optional[str]]] = Field(alias="subscribe")
+    promotion_data: Optional[list[Optional[PromotionDataV1]]] = Field(alias="promotion_data")
 
 
 class SaasResourceTemplateTargetV2_SaasSecretParametersV1_VaultSecretV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class SaasResourceTemplateTargetV2_SaasSecretParametersV1(ConfiguredBaseModel):
@@ -547,32 +547,32 @@ class SaasResourceTemplateTargetUpstreamV1(ConfiguredBaseModel):
 class SaasResourceTemplateTargetV2(ConfiguredBaseModel):
     namespace: SaasResourceTemplateTargetV2_NamespaceV1 = Field(..., alias="namespace")
     ref: str = Field(..., alias="ref")
-    promotion: Optional[SaasResourceTemplateTargetPromotionV1] = Field(..., alias="promotion")
-    parameters: Optional[Json] = Field(..., alias="parameters")
-    secret_parameters: Optional[list[Optional[SaasResourceTemplateTargetV2_SaasSecretParametersV1]]] = Field(..., alias="secretParameters")
-    upstream: Optional[SaasResourceTemplateTargetUpstreamV1] = Field(..., alias="upstream")
-    disable: Optional[bool] = Field(..., alias="disable")
-    delete: Optional[bool] = Field(..., alias="delete")
+    promotion: Optional[SaasResourceTemplateTargetPromotionV1] = Field(alias="promotion")
+    parameters: Optional[Json] = Field(alias="parameters")
+    secret_parameters: Optional[list[Optional[SaasResourceTemplateTargetV2_SaasSecretParametersV1]]] = Field(alias="secretParameters")
+    upstream: Optional[SaasResourceTemplateTargetUpstreamV1] = Field(alias="upstream")
+    disable: Optional[bool] = Field(alias="disable")
+    delete: Optional[bool] = Field(alias="delete")
 
 
 class SaasResourceTemplateV2(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     url: str = Field(..., alias="url")
     path: str = Field(..., alias="path")
-    provider: Optional[str] = Field(..., alias="provider")
-    hash_length: Optional[int] = Field(..., alias="hash_length")
-    parameters: Optional[Json] = Field(..., alias="parameters")
-    secret_parameters: Optional[list[Optional[SaasResourceTemplateV2_SaasSecretParametersV1]]] = Field(..., alias="secretParameters")
-    targets: Optional[list[SaasResourceTemplateTargetV2]] = Field(..., alias="targets")
+    provider: Optional[str] = Field(alias="provider")
+    hash_length: Optional[int] = Field(alias="hash_length")
+    parameters: Optional[Json] = Field(alias="parameters")
+    secret_parameters: Optional[list[Optional[SaasResourceTemplateV2_SaasSecretParametersV1]]] = Field(alias="secretParameters")
+    targets: Optional[list[SaasResourceTemplateTargetV2]] = Field(alias="targets")
 
 
 class UserV1(ConfiguredBaseModel):
     org_username: str = Field(..., alias="org_username")
-    tag_on_merge_requests: Optional[bool] = Field(..., alias="tag_on_merge_requests")
+    tag_on_merge_requests: Optional[bool] = Field(alias="tag_on_merge_requests")
 
 
 class RoleV1(ConfiguredBaseModel):
-    users: Optional[list[Optional[UserV1]]] = Field(..., alias="users")
+    users: Optional[list[Optional[UserV1]]] = Field(alias="users")
 
 
 class SaasFileV2(ConfiguredBaseModel):
@@ -580,24 +580,24 @@ class SaasFileV2(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     app: AppV1 = Field(..., alias="app")
     pipelines_provider: Union[PipelinesProviderTektonV1, PipelinesProviderV1] = Field(..., alias="pipelinesProvider")
-    deploy_resources: Optional[DeployResourcesV1] = Field(..., alias="deployResources")
-    slack: Optional[SlackOutputV1] = Field(..., alias="slack")
-    managed_resource_types: Optional[list[str]] = Field(..., alias="managedResourceTypes")
-    takeover: Optional[bool] = Field(..., alias="takeover")
-    compare: Optional[bool] = Field(..., alias="compare")
-    publish_job_logs: Optional[bool] = Field(..., alias="publishJobLogs")
-    cluster_admin: Optional[bool] = Field(..., alias="clusterAdmin")
-    image_patterns: Optional[list[str]] = Field(..., alias="imagePatterns")
-    use_channel_in_image_tag: Optional[bool] = Field(..., alias="use_channel_in_image_tag")
-    authentication: Optional[SaasFileAuthenticationV1] = Field(..., alias="authentication")
-    parameters: Optional[Json] = Field(..., alias="parameters")
-    secret_parameters: Optional[list[Optional[SaasSecretParametersV1]]] = Field(..., alias="secretParameters")
-    resource_templates: Optional[list[SaasResourceTemplateV2]] = Field(..., alias="resourceTemplates")
-    roles: Optional[list[Optional[RoleV1]]] = Field(..., alias="roles")
+    deploy_resources: Optional[DeployResourcesV1] = Field(alias="deployResources")
+    slack: Optional[SlackOutputV1] = Field(alias="slack")
+    managed_resource_types: Optional[list[str]] = Field(alias="managedResourceTypes")
+    takeover: Optional[bool] = Field(alias="takeover")
+    compare: Optional[bool] = Field(alias="compare")
+    publish_job_logs: Optional[bool] = Field(alias="publishJobLogs")
+    cluster_admin: Optional[bool] = Field(alias="clusterAdmin")
+    image_patterns: Optional[list[str]] = Field(alias="imagePatterns")
+    use_channel_in_image_tag: Optional[bool] = Field(alias="use_channel_in_image_tag")
+    authentication: Optional[SaasFileAuthenticationV1] = Field(alias="authentication")
+    parameters: Optional[Json] = Field(alias="parameters")
+    secret_parameters: Optional[list[Optional[SaasSecretParametersV1]]] = Field(alias="secretParameters")
+    resource_templates: Optional[list[SaasResourceTemplateV2]] = Field(alias="resourceTemplates")
+    roles: Optional[list[Optional[RoleV1]]] = Field(alias="roles")
 
 
 class SaasFilesV2XXLQueryData(ConfiguredBaseModel):
-    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(..., alias="saas_files")
+    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(alias="saas_files")
 
 
 def query(query_func: Callable, **kwargs: Any) -> SaasFilesV2XXLQueryData:

--- a/tests/generator/expected/pydantic_v1/complex_queries_with_fragments/saas_with_multiple_fragment_references.py.txt
+++ b/tests/generator/expected/pydantic_v1/complex_queries_with_fragments/saas_with_multiple_fragment_references.py.txt
@@ -97,8 +97,8 @@ class ClusterJumpHostV1(ConfiguredBaseModel):
 
 class ClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    jump_host: Optional[ClusterJumpHostV1] = Field(..., alias="jumpHost")
-    automation_token: Optional[VaultSecret] = Field(..., alias="automationToken")
+    jump_host: Optional[ClusterJumpHostV1] = Field(alias="jumpHost")
+    automation_token: Optional[VaultSecret] = Field(alias="automationToken")
 
 
 class NamespaceV1(ConfiguredBaseModel):
@@ -120,29 +120,29 @@ class SlackWorkspaceIntegrationV1(ConfiguredBaseModel):
 
 class SlackWorkspaceV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    integrations: Optional[list[Optional[SlackWorkspaceIntegrationV1]]] = Field(..., alias="integrations")
+    integrations: Optional[list[Optional[SlackWorkspaceIntegrationV1]]] = Field(alias="integrations")
 
 
 class SlackOutputNotificationsV1(ConfiguredBaseModel):
-    start: Optional[bool] = Field(..., alias="start")
+    start: Optional[bool] = Field(alias="start")
 
 
 class SlackOutputV1(ConfiguredBaseModel):
-    output: Optional[str] = Field(..., alias="output")
+    output: Optional[str] = Field(alias="output")
     workspace: SlackWorkspaceV1 = Field(..., alias="workspace")
-    channel: Optional[str] = Field(..., alias="channel")
-    notifications: Optional[SlackOutputNotificationsV1] = Field(..., alias="notifications")
+    channel: Optional[str] = Field(alias="channel")
+    notifications: Optional[SlackOutputNotificationsV1] = Field(alias="notifications")
 
 
 class SaasFileV2(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     name: str = Field(..., alias="name")
     pipelines_provider: Union[PipelinesProviderTektonV1, PipelinesProviderV1] = Field(..., alias="pipelinesProvider")
-    slack: Optional[SlackOutputV1] = Field(..., alias="slack")
+    slack: Optional[SlackOutputV1] = Field(alias="slack")
 
 
 class SaasFilesV2XXLQueryData(ConfiguredBaseModel):
-    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(..., alias="saas_files")
+    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(alias="saas_files")
 
 
 def query(query_func: Callable, **kwargs: Any) -> SaasFilesV2XXLQueryData:

--- a/tests/generator/expected/pydantic_v1/complex_queries_with_fragments/vault_secret_fragment.py.txt
+++ b/tests/generator/expected/pydantic_v1/complex_queries_with_fragments/vault_secret_fragment.py.txt
@@ -27,5 +27,5 @@ class ConfiguredBaseModel(BaseModel):
 class VaultSecret(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")

--- a/tests/generator/expected/pydantic_v1/custom_mappings/saas_file_json.py.txt
+++ b/tests/generator/expected/pydantic_v1/custom_mappings/saas_file_json.py.txt
@@ -39,7 +39,7 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class PipelinesProviderV1(ConfiguredBaseModel):
-    labels: Optional[str] = Field(..., alias="labels")
+    labels: Optional[str] = Field(alias="labels")
 
 
 class SaasFileV2(ConfiguredBaseModel):
@@ -47,11 +47,11 @@ class SaasFileV2(ConfiguredBaseModel):
 
 
 class AppV1(ConfiguredBaseModel):
-    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(..., alias="saasFiles")
+    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(alias="saasFiles")
 
 
 class SaasFilesWithEnumQueryData(ConfiguredBaseModel):
-    apps_v1: Optional[list[Optional[AppV1]]] = Field(..., alias="apps_v1")
+    apps_v1: Optional[list[Optional[AppV1]]] = Field(alias="apps_v1")
 
 
 def query(query_func: Callable, **kwargs: Any) -> SaasFilesWithEnumQueryData:

--- a/tests/generator/expected/pydantic_v1/fragments/multiple_nested_fragments.py.txt
+++ b/tests/generator/expected/pydantic_v1/fragments/multiple_nested_fragments.py.txt
@@ -29,5 +29,5 @@ class ConfiguredBaseModel(BaseModel):
 
 class MinimalCluster(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    jump_host: Optional[CommonJumphostFields] = Field(..., alias="jumpHost")
-    automation_token: Optional[VaultSecret] = Field(..., alias="automationToken")
+    jump_host: Optional[CommonJumphostFields] = Field(alias="jumpHost")
+    automation_token: Optional[VaultSecret] = Field(alias="automationToken")

--- a/tests/generator/expected/pydantic_v1/fragments/nested_fragment.py.txt
+++ b/tests/generator/expected/pydantic_v1/fragments/nested_fragment.py.txt
@@ -30,5 +30,5 @@ class CommonJumphostFields(ConfiguredBaseModel):
     hostname: str = Field(..., alias="hostname")
     known_hosts: str = Field(..., alias="knownHosts")
     user: str = Field(..., alias="user")
-    port: Optional[int] = Field(..., alias="port")
+    port: Optional[int] = Field(alias="port")
     identity: VaultSecret = Field(..., alias="identity")

--- a/tests/generator/expected/pydantic_v1/fragments/nested_layers.py.txt
+++ b/tests/generator/expected/pydantic_v1/fragments/nested_layers.py.txt
@@ -60,11 +60,11 @@ class ConfiguredBaseModel(BaseModel):
 
 class ClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    jump_host: Optional[CommonJumphostFields] = Field(..., alias="jumpHost")
+    jump_host: Optional[CommonJumphostFields] = Field(alias="jumpHost")
 
 
 class ClustersMinimalQueryData(ConfiguredBaseModel):
-    clusters_v1: Optional[list[Optional[ClusterV1]]] = Field(..., alias="clusters_v1")
+    clusters_v1: Optional[list[Optional[ClusterV1]]] = Field(alias="clusters_v1")
 
 
 def query(query_func: Callable, **kwargs: Any) -> ClustersMinimalQueryData:

--- a/tests/generator/expected/pydantic_v1/fragments/simple_fragment.py.txt
+++ b/tests/generator/expected/pydantic_v1/fragments/simple_fragment.py.txt
@@ -27,5 +27,5 @@ class ConfiguredBaseModel(BaseModel):
 class VaultSecret(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")

--- a/tests/generator/expected/pydantic_v1/fragments_2023_03/fragment_with_inline.py.txt
+++ b/tests/generator/expected/pydantic_v1/fragments_2023_03/fragment_with_inline.py.txt
@@ -31,50 +31,50 @@ class NamespaceOpenshiftResource(ConfiguredBaseModel):
 class ResourceV1(ConfiguredBaseModel):
     content: str = Field(..., alias="content")
     path: str = Field(..., alias="path")
-    schema: Optional[str] = Field(..., alias="schema")
+    schema: Optional[str] = Field(alias="schema")
 
 
 class NamespaceOpenshiftResourceResourceV1(NamespaceOpenshiftResource):
-    resource: Optional[ResourceV1] = Field(..., alias="resource")
-    validate_json: Optional[bool] = Field(..., alias="validate_json")
-    validate_alertmanager_config: Optional[bool] = Field(..., alias="validate_alertmanager_config")
-    alertmanager_config_key: Optional[str] = Field(..., alias="alertmanager_config_key")
-    enable_query_support: Optional[bool] = Field(..., alias="enable_query_support")
+    resource: Optional[ResourceV1] = Field(alias="resource")
+    validate_json: Optional[bool] = Field(alias="validate_json")
+    validate_alertmanager_config: Optional[bool] = Field(alias="validate_alertmanager_config")
+    alertmanager_config_key: Optional[str] = Field(alias="alertmanager_config_key")
+    enable_query_support: Optional[bool] = Field(alias="enable_query_support")
 
 
 class NamespaceOpenshiftResourceResourceTemplateV1_ResourceV1(ConfiguredBaseModel):
     content: str = Field(..., alias="content")
     path: str = Field(..., alias="path")
-    schema: Optional[str] = Field(..., alias="schema")
+    schema: Optional[str] = Field(alias="schema")
 
 
 class NamespaceOpenshiftResourceResourceTemplateV1(NamespaceOpenshiftResource):
-    resource: Optional[NamespaceOpenshiftResourceResourceTemplateV1_ResourceV1] = Field(..., alias="resource")
-    q_type: Optional[str] = Field(..., alias="type")
-    variables: Optional[Json] = Field(..., alias="variables")
-    validate_alertmanager_config: Optional[bool] = Field(..., alias="validate_alertmanager_config")
-    alertmanager_config_key: Optional[str] = Field(..., alias="alertmanager_config_key")
-    enable_query_support: Optional[bool] = Field(..., alias="enable_query_support")
+    resource: Optional[NamespaceOpenshiftResourceResourceTemplateV1_ResourceV1] = Field(alias="resource")
+    q_type: Optional[str] = Field(alias="type")
+    variables: Optional[Json] = Field(alias="variables")
+    validate_alertmanager_config: Optional[bool] = Field(alias="validate_alertmanager_config")
+    alertmanager_config_key: Optional[str] = Field(alias="alertmanager_config_key")
+    enable_query_support: Optional[bool] = Field(alias="enable_query_support")
 
 
 class NamespaceOpenshiftResourceVaultSecretV1(NamespaceOpenshiftResource):
     path: str = Field(..., alias="path")
     version: int = Field(..., alias="version")
-    name: Optional[str] = Field(..., alias="name")
-    labels: Optional[Json] = Field(..., alias="labels")
-    annotations: Optional[Json] = Field(..., alias="annotations")
-    q_type: Optional[str] = Field(..., alias="type")
-    validate_alertmanager_config: Optional[bool] = Field(..., alias="validate_alertmanager_config")
-    alertmanager_config_key: Optional[str] = Field(..., alias="alertmanager_config_key")
+    name: Optional[str] = Field(alias="name")
+    labels: Optional[Json] = Field(alias="labels")
+    annotations: Optional[Json] = Field(alias="annotations")
+    q_type: Optional[str] = Field(alias="type")
+    validate_alertmanager_config: Optional[bool] = Field(alias="validate_alertmanager_config")
+    alertmanager_config_key: Optional[str] = Field(alias="alertmanager_config_key")
 
 
 class NamespaceOpenshiftResourceRouteV1_ResourceV1(ConfiguredBaseModel):
     content: str = Field(..., alias="content")
     path: str = Field(..., alias="path")
-    schema: Optional[str] = Field(..., alias="schema")
+    schema: Optional[str] = Field(alias="schema")
 
 
 class NamespaceOpenshiftResourceRouteV1(NamespaceOpenshiftResource):
-    resource: Optional[NamespaceOpenshiftResourceRouteV1_ResourceV1] = Field(..., alias="resource")
-    vault_tls_secret_path: Optional[str] = Field(..., alias="vault_tls_secret_path")
-    vault_tls_secret_version: Optional[int] = Field(..., alias="vault_tls_secret_version")
+    resource: Optional[NamespaceOpenshiftResourceRouteV1_ResourceV1] = Field(alias="resource")
+    vault_tls_secret_path: Optional[str] = Field(alias="vault_tls_secret_path")
+    vault_tls_secret_version: Optional[int] = Field(alias="vault_tls_secret_version")

--- a/tests/generator/expected/pydantic_v1/github/comment_mutation.py.txt
+++ b/tests/generator/expected/pydantic_v1/github/comment_mutation.py.txt
@@ -58,11 +58,11 @@ class User(Node):
 
 
 class AddCommentPayload(ConfiguredBaseModel):
-    subject: Optional[Union[Topic, User, Node]] = Field(..., alias="subject")
+    subject: Optional[Union[Topic, User, Node]] = Field(alias="subject")
 
 
 class AddCommentMutationResponse(ConfiguredBaseModel):
-    add_comment: Optional[AddCommentPayload] = Field(..., alias="addComment")
+    add_comment: Optional[AddCommentPayload] = Field(alias="addComment")
 
 
 def mutate(mutation_func: Callable, **kwargs: Any) -> AddCommentMutationResponse:

--- a/tests/generator/expected/pydantic_v1/github/invitations_enum.py.txt
+++ b/tests/generator/expected/pydantic_v1/github/invitations_enum.py.txt
@@ -50,19 +50,19 @@ class OrganizationInvitation(ConfiguredBaseModel):
 
 
 class OrganizationInvitationConnection(ConfiguredBaseModel):
-    nodes: Optional[list[Optional[OrganizationInvitation]]] = Field(..., alias="nodes")
+    nodes: Optional[list[Optional[OrganizationInvitation]]] = Field(alias="nodes")
 
 
 class Team(ConfiguredBaseModel):
-    invitations: Optional[OrganizationInvitationConnection] = Field(..., alias="invitations")
+    invitations: Optional[OrganizationInvitationConnection] = Field(alias="invitations")
 
 
 class Organization(ConfiguredBaseModel):
-    team: Optional[Team] = Field(..., alias="team")
+    team: Optional[Team] = Field(alias="team")
 
 
 class GithubInvitationsQueryData(ConfiguredBaseModel):
-    organization: Optional[Organization] = Field(..., alias="organization")
+    organization: Optional[Organization] = Field(alias="organization")
 
 
 def query(query_func: Callable, **kwargs: Any) -> GithubInvitationsQueryData:

--- a/tests/generator/expected/pydantic_v1/github/issues_datetime_html.py.txt
+++ b/tests/generator/expected/pydantic_v1/github/issues_datetime_html.py.txt
@@ -45,7 +45,7 @@ class Issue(ConfiguredBaseModel):
 
 
 class IssueConnection(ConfiguredBaseModel):
-    nodes: Optional[list[Optional[Issue]]] = Field(..., alias="nodes")
+    nodes: Optional[list[Optional[Issue]]] = Field(alias="nodes")
 
 
 class Repository(ConfiguredBaseModel):
@@ -53,7 +53,7 @@ class Repository(ConfiguredBaseModel):
 
 
 class IssuesDateQueryData(ConfiguredBaseModel):
-    repository: Optional[Repository] = Field(..., alias="repository")
+    repository: Optional[Repository] = Field(alias="repository")
 
 
 def query(query_func: Callable, **kwargs: Any) -> IssuesDateQueryData:

--- a/tests/generator/expected/pydantic_v1/simple_queries/difficult_attribute_name.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries/difficult_attribute_name.py.txt
@@ -41,11 +41,11 @@ class ClusterV1(ConfiguredBaseModel):
 
 
 class AppInterfaceSettingsV1(ConfiguredBaseModel):
-    push_gateway_cluster: Optional[ClusterV1] = Field(..., alias="pushGatewayCluster")
+    push_gateway_cluster: Optional[ClusterV1] = Field(alias="pushGatewayCluster")
 
 
 class DifficultAttributeNameQueryData(ConfiguredBaseModel):
-    app_interface_settings_v1: Optional[list[Optional[AppInterfaceSettingsV1]]] = Field(..., alias="app_interface_settings_v1")
+    app_interface_settings_v1: Optional[list[Optional[AppInterfaceSettingsV1]]] = Field(alias="app_interface_settings_v1")
 
 
 def query(query_func: Callable, **kwargs: Any) -> DifficultAttributeNameQueryData:

--- a/tests/generator/expected/pydantic_v1/simple_queries/difficult_attribute_name_2.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries/difficult_attribute_name_2.py.txt
@@ -57,11 +57,11 @@ class SLODocumentSLOV1(ConfiguredBaseModel):
 
 
 class SLODocumentV1(ConfiguredBaseModel):
-    slos: Optional[list[Optional[SLODocumentSLOV1]]] = Field(..., alias="slos")
+    slos: Optional[list[Optional[SLODocumentSLOV1]]] = Field(alias="slos")
 
 
 class SLODocumentsQueryData(ConfiguredBaseModel):
-    slo_documents: Optional[list[Optional[SLODocumentV1]]] = Field(..., alias="slo_documents")
+    slo_documents: Optional[list[Optional[SLODocumentV1]]] = Field(alias="slo_documents")
 
 
 def query(query_func: Callable, **kwargs: Any) -> SLODocumentsQueryData:

--- a/tests/generator/expected/pydantic_v1/simple_queries/saas_file_json.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries/saas_file_json.py.txt
@@ -39,7 +39,7 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class PipelinesProviderV1(ConfiguredBaseModel):
-    labels: Optional[Json] = Field(..., alias="labels")
+    labels: Optional[Json] = Field(alias="labels")
 
 
 class SaasFileV2(ConfiguredBaseModel):
@@ -47,11 +47,11 @@ class SaasFileV2(ConfiguredBaseModel):
 
 
 class AppV1(ConfiguredBaseModel):
-    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(..., alias="saasFiles")
+    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(alias="saasFiles")
 
 
 class SaasFilesWithEnumQueryData(ConfiguredBaseModel):
-    apps_v1: Optional[list[Optional[AppV1]]] = Field(..., alias="apps_v1")
+    apps_v1: Optional[list[Optional[AppV1]]] = Field(alias="apps_v1")
 
 
 def query(query_func: Callable, **kwargs: Any) -> SaasFilesWithEnumQueryData:

--- a/tests/generator/expected/pydantic_v1/simple_queries/saas_file_reduced.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries/saas_file_reduced.py.txt
@@ -41,11 +41,11 @@ class SaasFileV2(ConfiguredBaseModel):
 
 
 class AppV1(ConfiguredBaseModel):
-    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(..., alias="saasFiles")
+    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(alias="saasFiles")
 
 
 class SaasFilesReducedQueryData(ConfiguredBaseModel):
-    apps_v1: Optional[list[Optional[AppV1]]] = Field(..., alias="apps_v1")
+    apps_v1: Optional[list[Optional[AppV1]]] = Field(alias="apps_v1")
 
 
 def query(query_func: Callable, **kwargs: Any) -> SaasFilesReducedQueryData:

--- a/tests/generator/expected/pydantic_v1/simple_queries/saas_file_simple.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries/saas_file_simple.py.txt
@@ -49,11 +49,11 @@ class SaasFileV2(ConfiguredBaseModel):
 
 
 class AppV1(ConfiguredBaseModel):
-    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(..., alias="saasFiles")
+    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(alias="saasFiles")
 
 
 class SaasFilesSimpleQueryData(ConfiguredBaseModel):
-    apps_v1: Optional[list[Optional[AppV1]]] = Field(..., alias="apps_v1")
+    apps_v1: Optional[list[Optional[AppV1]]] = Field(alias="apps_v1")
 
 
 def query(query_func: Callable, **kwargs: Any) -> SaasFilesSimpleQueryData:

--- a/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query.py.txt
@@ -54,12 +54,12 @@ class ConfiguredBaseModel(BaseModel):
 
 class OpenShiftClusterManagerV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    offline_token: Optional[VaultSecret] = Field(..., alias="offlineToken")
+    offline_token: Optional[VaultSecret] = Field(alias="offlineToken")
 
 
 class ClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    ocm: Optional[OpenShiftClusterManagerV1] = Field(..., alias="ocm")
+    ocm: Optional[OpenShiftClusterManagerV1] = Field(alias="ocm")
 
 
 class OcpReleaseMirrorV1(ConfiguredBaseModel):
@@ -67,7 +67,7 @@ class OcpReleaseMirrorV1(ConfiguredBaseModel):
 
 
 class OCPAuthFullQueryData(ConfiguredBaseModel):
-    ocp_release_mirror: Optional[list[Optional[OcpReleaseMirrorV1]]] = Field(..., alias="ocp_release_mirror")
+    ocp_release_mirror: Optional[list[Optional[OcpReleaseMirrorV1]]] = Field(alias="ocp_release_mirror")
 
 
 def query(query_func: Callable, **kwargs: Any) -> OCPAuthFullQueryData:

--- a/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query_multiple.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query_multiple.py.txt
@@ -59,17 +59,17 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class VaultSecretV1(VaultSecretPartial, VaultSecretVersion):
-    q_format: Optional[str] = Field(..., alias="format")
+    q_format: Optional[str] = Field(alias="format")
 
 
 class OpenShiftClusterManagerV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    offline_token: Optional[VaultSecretV1] = Field(..., alias="offlineToken")
+    offline_token: Optional[VaultSecretV1] = Field(alias="offlineToken")
 
 
 class ClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    ocm: Optional[OpenShiftClusterManagerV1] = Field(..., alias="ocm")
+    ocm: Optional[OpenShiftClusterManagerV1] = Field(alias="ocm")
 
 
 class OcpReleaseMirrorV1(ConfiguredBaseModel):
@@ -77,7 +77,7 @@ class OcpReleaseMirrorV1(ConfiguredBaseModel):
 
 
 class OCPAuthMultipleQueryData(ConfiguredBaseModel):
-    ocp_release_mirror: Optional[list[Optional[OcpReleaseMirrorV1]]] = Field(..., alias="ocp_release_mirror")
+    ocp_release_mirror: Optional[list[Optional[OcpReleaseMirrorV1]]] = Field(alias="ocp_release_mirror")
 
 
 def query(query_func: Callable, **kwargs: Any) -> OCPAuthMultipleQueryData:

--- a/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query_partial.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query_partial.py.txt
@@ -53,18 +53,18 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class VaultSecretV1(VaultSecretPartial):
-    q_format: Optional[str] = Field(..., alias="format")
-    version: Optional[int] = Field(..., alias="version")
+    q_format: Optional[str] = Field(alias="format")
+    version: Optional[int] = Field(alias="version")
 
 
 class OpenShiftClusterManagerV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    offline_token: Optional[VaultSecretV1] = Field(..., alias="offlineToken")
+    offline_token: Optional[VaultSecretV1] = Field(alias="offlineToken")
 
 
 class ClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    ocm: Optional[OpenShiftClusterManagerV1] = Field(..., alias="ocm")
+    ocm: Optional[OpenShiftClusterManagerV1] = Field(alias="ocm")
 
 
 class OcpReleaseMirrorV1(ConfiguredBaseModel):
@@ -72,7 +72,7 @@ class OcpReleaseMirrorV1(ConfiguredBaseModel):
 
 
 class OCPAuthPartialQueryData(ConfiguredBaseModel):
-    ocp_release_mirror: Optional[list[Optional[OcpReleaseMirrorV1]]] = Field(..., alias="ocp_release_mirror")
+    ocp_release_mirror: Optional[list[Optional[OcpReleaseMirrorV1]]] = Field(alias="ocp_release_mirror")
 
 
 def query(query_func: Callable, **kwargs: Any) -> OCPAuthPartialQueryData:

--- a/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/vault_secret_fragment.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/vault_secret_fragment.py.txt
@@ -27,5 +27,5 @@ class ConfiguredBaseModel(BaseModel):
 class VaultSecret(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     field: str = Field(..., alias="field")
-    version: Optional[int] = Field(..., alias="version")
-    q_format: Optional[str] = Field(..., alias="format")
+    version: Optional[int] = Field(alias="version")
+    q_format: Optional[str] = Field(alias="format")

--- a/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/vault_secret_version_fragment.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/vault_secret_version_fragment.py.txt
@@ -25,4 +25,4 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class VaultSecretVersion(ConfiguredBaseModel):
-    version: Optional[int] = Field(..., alias="version")
+    version: Optional[int] = Field(alias="version")


### PR DESCRIPTION
If a field is Optional, generated code shouldn't mark it as required like `Field(..., alias="some_alias")`, [doc](https://docs.pydantic.dev/usage/models/#required-fields).

This change will allow dynamic graphql response with directives to pass validation.