### PR TITLE
set allow_population_by_field_name pydantic config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Qenerate Changelog
 
+## 0.6.2
+
+New Features:
+
+* Set `allow_population_by_field_name` Pydantic [model config](https://docs.pydantic.dev/1.10/usage/model_config/#options)
+
 ## 0.6.1
 
 BUGFIX:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qenerate"
-version = "0.6.1"
+version = "0.6.2"
 description = "Code Generator for GraphQL Query and Fragment Data Classes"
 authors = [
     "Red Hat - Service Delivery - AppSRE <sd-app-sre@redhat.com>"

--- a/qenerate/plugins/pydantic_v1/plugin.py
+++ b/qenerate/plugins/pydantic_v1/plugin.py
@@ -72,7 +72,8 @@ CONF = (
     # https://pydantic-docs.helpmanual.io/usage/model_config/#smart-union
     # https://stackoverflow.com/a/69705356/4478420
     f"{INDENT}{INDENT}smart_union=True\n"
-    f"{INDENT}{INDENT}extra=Extra.forbid"
+    f"{INDENT}{INDENT}extra=Extra.forbid\n"
+    f"{INDENT}{INDENT}allow_population_by_field_name=True"
 )
 
 

--- a/tests/generator/expected/pydantic_v1/complex_queries/enumerate_collisions.py.txt
+++ b/tests/generator/expected/pydantic_v1/complex_queries/enumerate_collisions.py.txt
@@ -59,6 +59,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class ClusterSpecV1(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/complex_queries/ocp_with_inline_fragments.py.txt
+++ b/tests/generator/expected/pydantic_v1/complex_queries/ocp_with_inline_fragments.py.txt
@@ -42,6 +42,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class ClusterAuthV1(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/complex_queries/saas_humongous.py.txt
+++ b/tests/generator/expected/pydantic_v1/complex_queries/saas_humongous.py.txt
@@ -260,6 +260,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class AppV1(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/complex_queries_with_fragments/saas_with_multiple_fragment_references.py.txt
+++ b/tests/generator/expected/pydantic_v1/complex_queries_with_fragments/saas_with_multiple_fragment_references.py.txt
@@ -83,6 +83,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class PipelinesProviderV1(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/complex_queries_with_fragments/vault_secret_fragment.py.txt
+++ b/tests/generator/expected/pydantic_v1/complex_queries_with_fragments/vault_secret_fragment.py.txt
@@ -22,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class VaultSecret(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/custom_mappings/saas_file_json.py.txt
+++ b/tests/generator/expected/pydantic_v1/custom_mappings/saas_file_json.py.txt
@@ -36,6 +36,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class PipelinesProviderV1(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/fragments/multiple_nested_fragments.py.txt
+++ b/tests/generator/expected/pydantic_v1/fragments/multiple_nested_fragments.py.txt
@@ -25,6 +25,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class MinimalCluster(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/fragments/nested_fragment.py.txt
+++ b/tests/generator/expected/pydantic_v1/fragments/nested_fragment.py.txt
@@ -24,6 +24,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class CommonJumphostFields(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/fragments/nested_layers.py.txt
+++ b/tests/generator/expected/pydantic_v1/fragments/nested_layers.py.txt
@@ -56,6 +56,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class ClusterV1(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/fragments/simple_fragment.py.txt
+++ b/tests/generator/expected/pydantic_v1/fragments/simple_fragment.py.txt
@@ -22,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class VaultSecret(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/fragments_2023_03/fragment_with_inline.py.txt
+++ b/tests/generator/expected/pydantic_v1/fragments_2023_03/fragment_with_inline.py.txt
@@ -22,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class NamespaceOpenshiftResource(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/github/comment_mutation.py.txt
+++ b/tests/generator/expected/pydantic_v1/github/comment_mutation.py.txt
@@ -41,6 +41,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class Node(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/github/invitations_enum.py.txt
+++ b/tests/generator/expected/pydantic_v1/github/invitations_enum.py.txt
@@ -38,6 +38,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class OrganizationInvitationType(Enum):

--- a/tests/generator/expected/pydantic_v1/github/issues_datetime_html.py.txt
+++ b/tests/generator/expected/pydantic_v1/github/issues_datetime_html.py.txt
@@ -37,6 +37,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class Issue(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/simple_queries/difficult_attribute_name.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries/difficult_attribute_name.py.txt
@@ -34,6 +34,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class ClusterV1(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/simple_queries/difficult_attribute_name_2.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries/difficult_attribute_name_2.py.txt
@@ -41,6 +41,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class SLODocumentSLOSLOParametersV1(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/simple_queries/saas_file_json.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries/saas_file_json.py.txt
@@ -36,6 +36,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class PipelinesProviderV1(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/simple_queries/saas_file_reduced.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries/saas_file_reduced.py.txt
@@ -34,6 +34,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class SaasFileV2(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/simple_queries/saas_file_simple.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries/saas_file_simple.py.txt
@@ -37,6 +37,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class PipelinesProviderV1(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query.py.txt
@@ -50,6 +50,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class OpenShiftClusterManagerV1(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query_multiple.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query_multiple.py.txt
@@ -56,6 +56,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class VaultSecretV1(VaultSecretPartial, VaultSecretVersion):

--- a/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query_partial.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/ocp_query_partial.py.txt
@@ -50,6 +50,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class VaultSecretV1(VaultSecretPartial):

--- a/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/vault_secret_fragment.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/vault_secret_fragment.py.txt
@@ -22,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class VaultSecret(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/vault_secret_partial_fragment.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/vault_secret_partial_fragment.py.txt
@@ -22,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class VaultSecretPartial(ConfiguredBaseModel):

--- a/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/vault_secret_version_fragment.py.txt
+++ b/tests/generator/expected/pydantic_v1/simple_queries_with_fragments/vault_secret_version_fragment.py.txt
@@ -22,6 +22,7 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+        allow_population_by_field_name=True
 
 
 class VaultSecretVersion(ConfiguredBaseModel):


### PR DESCRIPTION
Set the Pydantic config `allow_population_by_field_name`. This allows the initialization of Pydantic classes with either the GQL aliases or the Python class attribute names. This will make it easier to print and copy and paste a Pydantic object to tests, for example.