### PR TITLE
introduce ruff as code checker and formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .vscode
 .mypy_cache
 demo/gql/introspection.json
+.ruff_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Qenerate Changelog
 
+## 0.6.4 (unreleased)
+
+* Use [ruff](https://docs.astral.sh/ruff/) to check and format the code
+
 ## 0.6.3
 
 Bugfixes:
 
 * revert `allow_population_by_field_name` Pydantic model config. This was causing troubles with mypy.
-*
+
 ## 0.6.2
 
 New Features:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ USER root
 COPY . .
 
 RUN pip install --upgrade pip && \
-    pip install poetry==1.1.13
+    pip install poetry==1.2.2
 RUN make venv
 RUN make test

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,14 @@ venv:
 	. .venv/bin/activate && pip install poetry2setup
 
 format:
-	poetry run black qenerate tests
+	poetry run ruff format
+	poetry run ruff check
 
 setup.py:
 	. .venv/bin/activate && poetry2setup > setup.py
-	
+
 test:
 	poetry run pytest -vv
-	poetry run flake8 qenerate
+	poetry run ruff format --check
+	poetry run ruff check --no-fix
 	poetry run mypy qenerate
-	poetry run black --check qenerate tests

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `qenerate` is a pluggable code generator for GraphQL Query and Fragment Data Classes.
 It works hand in hand with GraphQL clients like [gql](https://github.com/graphql-python/gql).
-Clients like gql return nested untyped dictionaries as result to a query. 
+Clients like gql return nested untyped dictionaries as result to a query.
 `qenerate` generated classes easily transform these nested untyped dictionaries into concrete classes.
 `qenerate` itself is not a GraphQL client and solely focuses on generating code
 for transforming untyped dictionaries into concrete types.
@@ -44,7 +44,7 @@ while traversing the given directory.
 Note, that the given directory and every `gql.` file in it share the same scope.
 I.e., within this scope fragment and query names must be unique. Further, you can
 freely use any fragment within queries, as long as the fragment is defined somewhere
-within the scope (directory). 
+within the scope (directory).
 
 #### Example for Single Query
 
@@ -135,7 +135,7 @@ parent node in the query as a prefix.
 This strategy adds the number of occurrences of this name as a suffix.
 
 However, in most cases it might be cleaner to define a re-usable fragment instead of
-relying on a collision strategy. Here are some [fragment examples](https://github.com/app-sre/qontract-reconcile/tree/master/reconcile/gql_definitions/fragments). 
+relying on a collision strategy. Here are some [fragment examples](https://github.com/app-sre/qontract-reconcile/tree/master/reconcile/gql_definitions/fragments).
 
 ## Limitations
 
@@ -173,7 +173,7 @@ Work on this is being conducted in [#77](https://github.com/app-sre/qenerate/pul
 CI happens on an [app-sre](https://github.com/app-sre/) owned Jenkins instance.
 
 - [Releases](https://ci.ext.devshift.net/job/app-sre-qenerate-gh-build-main/)
-- [PR Checks](https://ci.ext.devshift.net/job/app-sre-qenerate-gh-pr-check/) 
+- [PR Checks](https://ci.ext.devshift.net/job/app-sre-qenerate-gh-pr-check/)
 
 ### Build and Dependency Management
 
@@ -181,7 +181,7 @@ CI happens on an [app-sre](https://github.com/app-sre/) owned Jenkins instance.
 
 ### Formatting
 
-`qenerate` uses [black](https://github.com/psf/black) for formatting.
+`qenerate` uses [ruff](https://docs.astral.sh/ruff/) for code checking and formatting.
 
 ### Generating setup.py
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,32 +15,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
-
-[[package]]
-name = "black"
-version = "22.3.0"
-description = "The uncompromising code formatter."
-category = "dev"
-optional = false
-python-versions = ">=3.6.2"
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
 
 [[package]]
 name = "certifi"
@@ -59,18 +37,7 @@ optional = false
 python-versions = ">=3.5.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
-
-[[package]]
-name = "click"
-version = "8.1.3"
-description = "Composable command line interface toolkit"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "colorama"
@@ -79,19 +46,6 @@ description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
-name = "flake8"
-version = "4.0.1"
-description = "the modular source code checker: pep8 pyflakes and co"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.8.0,<2.9.0"
-pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
 name = "graphql-core"
@@ -110,14 +64,6 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
-name = "mccabe"
-version = "0.6.1"
-description = "McCabe checker, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "more-itertools"
 version = "8.13.0"
 description = "More routines for operating on iterables, beyond itertools"
@@ -127,29 +73,30 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "mypy"
-version = "0.961"
+version = "1.8.0"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 
 [package.dependencies]
-mypy-extensions = ">=0.4.3"
+mypy-extensions = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = ">=3.10"
+typing-extensions = ">=4.1.0"
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
-python2 = ["typed-ast (>=1.4.0,<2)"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
 reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.5"
 
 [[package]]
 name = "packaging"
@@ -161,26 +108,6 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
-
-[[package]]
-name = "pathspec"
-version = "0.9.0"
-description = "Utility library for gitignore style pattern matching of file paths."
-category = "dev"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-
-[[package]]
-name = "platformdirs"
-version = "2.5.2"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
 
 [[package]]
 name = "pluggy"
@@ -202,28 +129,12 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "pycodestyle"
-version = "2.8.0"
-description = "Python style guide checker"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
 name = "pyfakefs"
 version = "4.5.6"
 description = "pyfakefs implements a fake file system that mocks the Python file system modules."
 category = "dev"
 optional = false
 python-versions = ">=3.6"
-
-[[package]]
-name = "pyflakes"
-version = "2.4.0"
-description = "passive checker of Python programs"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyparsing"
@@ -234,7 +145,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["railroad-diagrams", "jinja2"]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -274,7 +185,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "requests-mock"
@@ -291,6 +202,14 @@ six = "*"
 [package.extras]
 fixture = ["fixtures"]
 test = ["fixtures", "mock", "purl", "pytest", "sphinx", "testrepository (>=0.0.18)", "testtools"]
+
+[[package]]
+name = "ruff"
+version = "0.1.11"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
 
 [[package]]
 name = "six"
@@ -344,8 +263,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
-brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -359,7 +278,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "663271ad025a46abcc313f824d8588b99ebe2b38bd46d1d4fe7395d9a86ff71a"
+content-hash = "946650871a5ee7154e2c54dc0c87325ef0ca47e6316c1a5692748be952fc8d2d"
 
 [metadata.files]
 atomicwrites = [
@@ -370,31 +289,6 @@ attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
-black = [
-    {file = "black-22.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09"},
-    {file = "black-22.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb"},
-    {file = "black-22.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e3556168e2e5c49629f7b0f377070240bd5511e45e25a4497bb0073d9dda776a"},
-    {file = "black-22.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67c8301ec94e3bcc8906740fe071391bce40a862b7be0b86fb5382beefecd968"},
-    {file = "black-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"},
-    {file = "black-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc1e1de68c8e5444e8f94c3670bb48a2beef0e91dddfd4fcc29595ebd90bb9ce"},
-    {file = "black-22.3.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2fc92002d44746d3e7db7cf9313cf4452f43e9ea77a2c939defce3b10b5c82"},
-    {file = "black-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a6342964b43a99dbc72f72812bf88cad8f0217ae9acb47c0d4f141a6416d2d7b"},
-    {file = "black-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:328efc0cc70ccb23429d6be184a15ce613f676bdfc85e5fe8ea2a9354b4e9015"},
-    {file = "black-22.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b"},
-    {file = "black-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ad4efa5fad66b903b4a5f96d91461d90b9507a812b3c5de657d544215bb7877a"},
-    {file = "black-22.3.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8477ec6bbfe0312c128e74644ac8a02ca06bcdb8982d4ee06f209be28cdf163"},
-    {file = "black-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:637a4014c63fbf42a692d22b55d8ad6968a946b4a6ebc385c5505d9625b6a464"},
-    {file = "black-22.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:863714200ada56cbc366dc9ae5291ceb936573155f8bf8e9de92aef51f3ad0f0"},
-    {file = "black-22.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10dbe6e6d2988049b4655b2b739f98785a884d4d6b85bc35133a8fb9a2233176"},
-    {file = "black-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:cee3e11161dde1b2a33a904b850b0899e0424cc331b7295f2a9698e79f9a69a0"},
-    {file = "black-22.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5891ef8abc06576985de8fa88e95ab70641de6c1fca97e2a15820a9b69e51b20"},
-    {file = "black-22.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:30d78ba6bf080eeaf0b7b875d924b15cd46fec5fd044ddfbad38c8ea9171043a"},
-    {file = "black-22.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee8f1f7228cce7dffc2b464f07ce769f478968bfb3dd1254a4c2eeed84928aad"},
-    {file = "black-22.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ee227b696ca60dd1c507be80a6bc849a5a6ab57ac7352aad1ffec9e8b805f21"},
-    {file = "black-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265"},
-    {file = "black-22.3.0-py3-none-any.whl", hash = "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72"},
-    {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
-]
 certifi = [
     {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
     {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
@@ -403,17 +297,9 @@ charset-normalizer = [
     {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
-click = [
-    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
-    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
-]
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
-]
-flake8 = [
-    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
-    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
 graphql-core = [
     {file = "graphql-core-3.2.1.tar.gz", hash = "sha256:9d1bf141427b7d54be944587c8349df791ce60ade2e3cccaf9c56368c133c201"},
@@ -423,54 +309,46 @@ idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
-mccabe = [
-    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
-    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
-]
 more-itertools = [
     {file = "more-itertools-8.13.0.tar.gz", hash = "sha256:a42901a0a5b169d925f6f217cd5a190e32ef54360905b9c39ee7db5313bfec0f"},
     {file = "more_itertools-8.13.0-py3-none-any.whl", hash = "sha256:c5122bffc5f104d37c1626b8615b511f3427aa5389b94d61e5ef8236bfbc3ddb"},
 ]
 mypy = [
-    {file = "mypy-0.961-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:697540876638ce349b01b6786bc6094ccdaba88af446a9abb967293ce6eaa2b0"},
-    {file = "mypy-0.961-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b117650592e1782819829605a193360a08aa99f1fc23d1d71e1a75a142dc7e15"},
-    {file = "mypy-0.961-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bdd5ca340beffb8c44cb9dc26697628d1b88c6bddf5c2f6eb308c46f269bb6f3"},
-    {file = "mypy-0.961-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3e09f1f983a71d0672bbc97ae33ee3709d10c779beb613febc36805a6e28bb4e"},
-    {file = "mypy-0.961-cp310-cp310-win_amd64.whl", hash = "sha256:e999229b9f3198c0c880d5e269f9f8129c8862451ce53a011326cad38b9ccd24"},
-    {file = "mypy-0.961-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b24be97351084b11582fef18d79004b3e4db572219deee0212078f7cf6352723"},
-    {file = "mypy-0.961-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f4a21d01fc0ba4e31d82f0fff195682e29f9401a8bdb7173891070eb260aeb3b"},
-    {file = "mypy-0.961-cp36-cp36m-win_amd64.whl", hash = "sha256:439c726a3b3da7ca84a0199a8ab444cd8896d95012c4a6c4a0d808e3147abf5d"},
-    {file = "mypy-0.961-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5a0b53747f713f490affdceef835d8f0cb7285187a6a44c33821b6d1f46ed813"},
-    {file = "mypy-0.961-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0e9f70df36405c25cc530a86eeda1e0867863d9471fe76d1273c783df3d35c2e"},
-    {file = "mypy-0.961-cp37-cp37m-win_amd64.whl", hash = "sha256:b88f784e9e35dcaa075519096dc947a388319cb86811b6af621e3523980f1c8a"},
-    {file = "mypy-0.961-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d5aaf1edaa7692490f72bdb9fbd941fbf2e201713523bdb3f4038be0af8846c6"},
-    {file = "mypy-0.961-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9f5f5a74085d9a81a1f9c78081d60a0040c3efb3f28e5c9912b900adf59a16e6"},
-    {file = "mypy-0.961-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f4b794db44168a4fc886e3450201365c9526a522c46ba089b55e1f11c163750d"},
-    {file = "mypy-0.961-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:64759a273d590040a592e0f4186539858c948302c653c2eac840c7a3cd29e51b"},
-    {file = "mypy-0.961-cp38-cp38-win_amd64.whl", hash = "sha256:63e85a03770ebf403291ec50097954cc5caf2a9205c888ce3a61bd3f82e17569"},
-    {file = "mypy-0.961-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f1332964963d4832a94bebc10f13d3279be3ce8f6c64da563d6ee6e2eeda932"},
-    {file = "mypy-0.961-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:006be38474216b833eca29ff6b73e143386f352e10e9c2fbe76aa8549e5554f5"},
-    {file = "mypy-0.961-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9940e6916ed9371809b35b2154baf1f684acba935cd09928952310fbddaba648"},
-    {file = "mypy-0.961-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a5ea0875a049de1b63b972456542f04643daf320d27dc592d7c3d9cd5d9bf950"},
-    {file = "mypy-0.961-cp39-cp39-win_amd64.whl", hash = "sha256:1ece702f29270ec6af25db8cf6185c04c02311c6bb21a69f423d40e527b75c56"},
-    {file = "mypy-0.961-py3-none-any.whl", hash = "sha256:03c6cc893e7563e7b2949b969e63f02c000b32502a1b4d1314cabe391aa87d66"},
-    {file = "mypy-0.961.tar.gz", hash = "sha256:f730d56cb924d371c26b8eaddeea3cc07d78ff51c521c6d04899ac6904b75492"},
+    {file = "mypy-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:485a8942f671120f76afffff70f259e1cd0f0cfe08f81c05d8816d958d4577d3"},
+    {file = "mypy-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:df9824ac11deaf007443e7ed2a4a26bebff98d2bc43c6da21b2b64185da011c4"},
+    {file = "mypy-1.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2afecd6354bbfb6e0160f4e4ad9ba6e4e003b767dd80d85516e71f2e955ab50d"},
+    {file = "mypy-1.8.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8963b83d53ee733a6e4196954502b33567ad07dfd74851f32be18eb932fb1cb9"},
+    {file = "mypy-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:e46f44b54ebddbeedbd3d5b289a893219065ef805d95094d16a0af6630f5d410"},
+    {file = "mypy-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:855fe27b80375e5c5878492f0729540db47b186509c98dae341254c8f45f42ae"},
+    {file = "mypy-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4c886c6cce2d070bd7df4ec4a05a13ee20c0aa60cb587e8d1265b6c03cf91da3"},
+    {file = "mypy-1.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d19c413b3c07cbecf1f991e2221746b0d2a9410b59cb3f4fb9557f0365a1a817"},
+    {file = "mypy-1.8.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9261ed810972061388918c83c3f5cd46079d875026ba97380f3e3978a72f503d"},
+    {file = "mypy-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:51720c776d148bad2372ca21ca29256ed483aa9a4cdefefcef49006dff2a6835"},
+    {file = "mypy-1.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:52825b01f5c4c1c4eb0db253ec09c7aa17e1a7304d247c48b6f3599ef40db8bd"},
+    {file = "mypy-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5ac9a4eeb1ec0f1ccdc6f326bcdb464de5f80eb07fb38b5ddd7b0de6bc61e55"},
+    {file = "mypy-1.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afe3fe972c645b4632c563d3f3eff1cdca2fa058f730df2b93a35e3b0c538218"},
+    {file = "mypy-1.8.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:42c6680d256ab35637ef88891c6bd02514ccb7e1122133ac96055ff458f93fc3"},
+    {file = "mypy-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:720a5ca70e136b675af3af63db533c1c8c9181314d207568bbe79051f122669e"},
+    {file = "mypy-1.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:028cf9f2cae89e202d7b6593cd98db6759379f17a319b5faf4f9978d7084cdc6"},
+    {file = "mypy-1.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4e6d97288757e1ddba10dd9549ac27982e3e74a49d8d0179fc14d4365c7add66"},
+    {file = "mypy-1.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f1478736fcebb90f97e40aff11a5f253af890c845ee0c850fe80aa060a267c6"},
+    {file = "mypy-1.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:42419861b43e6962a649068a61f4a4839205a3ef525b858377a960b9e2de6e0d"},
+    {file = "mypy-1.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:2b5b6c721bd4aabaadead3a5e6fa85c11c6c795e0c81a7215776ef8afc66de02"},
+    {file = "mypy-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5c1538c38584029352878a0466f03a8ee7547d7bd9f641f57a0f3017a7c905b8"},
+    {file = "mypy-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4ef4be7baf08a203170f29e89d79064463b7fc7a0908b9d0d5114e8009c3a259"},
+    {file = "mypy-1.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7178def594014aa6c35a8ff411cf37d682f428b3b5617ca79029d8ae72f5402b"},
+    {file = "mypy-1.8.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ab3c84fa13c04aeeeabb2a7f67a25ef5d77ac9d6486ff33ded762ef353aa5592"},
+    {file = "mypy-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:99b00bc72855812a60d253420d8a2eae839b0afa4938f09f4d2aa9bb4654263a"},
+    {file = "mypy-1.8.0-py3-none-any.whl", hash = "sha256:538fd81bb5e430cc1381a443971c0475582ff9f434c16cd46d2c66763ce85d9d"},
+    {file = "mypy-1.8.0.tar.gz", hash = "sha256:6ff8b244d7085a0b425b56d327b480c3b29cafbd2eff27316a004f9a7391ae07"},
 ]
 mypy-extensions = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
-]
-pathspec = [
-    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
-    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
-]
-platformdirs = [
-    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
-    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
@@ -480,17 +358,9 @@ py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
-pycodestyle = [
-    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
-    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
-]
 pyfakefs = [
     {file = "pyfakefs-4.5.6-py3-none-any.whl", hash = "sha256:6bb4e27457b0bc90e3ebfe5aed4f1b8c32a18713ba44e925f304bb9b9816a03c"},
     {file = "pyfakefs-4.5.6.tar.gz", hash = "sha256:914d7bf994406cfbefee0b4d45918f60c15b406afe93f8194a804da5a450a822"},
-]
-pyflakes = [
-    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
-    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
@@ -507,6 +377,25 @@ requests = [
 requests-mock = [
     {file = "requests-mock-1.9.3.tar.gz", hash = "sha256:8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba"},
     {file = "requests_mock-1.9.3-py2.py3-none-any.whl", hash = "sha256:0a2d38a117c08bb78939ec163522976ad59a6b7fdd82b709e23bb98004a44970"},
+]
+ruff = [
+    {file = "ruff-0.1.11-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a7f772696b4cdc0a3b2e527fc3c7ccc41cdcb98f5c80fdd4f2b8c50eb1458196"},
+    {file = "ruff-0.1.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:934832f6ed9b34a7d5feea58972635c2039c7a3b434fe5ba2ce015064cb6e955"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea0d3e950e394c4b332bcdd112aa566010a9f9c95814844a7468325290aabfd9"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9bd4025b9c5b429a48280785a2b71d479798a69f5c2919e7d274c5f4b32c3607"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1ad00662305dcb1e987f5ec214d31f7d6a062cae3e74c1cbccef15afd96611d"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4b077ce83f47dd6bea1991af08b140e8b8339f0ba8cb9b7a484c30ebab18a23f"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4a88efecec23c37b11076fe676e15c6cdb1271a38f2b415e381e87fe4517f18"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5b25093dad3b055667730a9b491129c42d45e11cdb7043b702e97125bcec48a1"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:231d8fb11b2cc7c0366a326a66dafc6ad449d7fcdbc268497ee47e1334f66f77"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:09c415716884950080921dd6237767e52e227e397e2008e2bed410117679975b"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0f58948c6d212a6b8d41cd59e349751018797ce1727f961c2fa755ad6208ba45"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:190a566c8f766c37074d99640cd9ca3da11d8deae2deae7c9505e68a4a30f740"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6464289bd67b2344d2a5d9158d5eb81025258f169e69a46b741b396ffb0cda95"},
+    {file = "ruff-0.1.11-py3-none-win32.whl", hash = "sha256:9b8f397902f92bc2e70fb6bebfa2139008dc72ae5177e66c383fa5426cb0bf2c"},
+    {file = "ruff-0.1.11-py3-none-win_amd64.whl", hash = "sha256:eb85ee287b11f901037a6683b2374bb0ec82928c5cbc984f575d0437979c521a"},
+    {file = "ruff-0.1.11-py3-none-win_arm64.whl", hash = "sha256:97ce4d752f964ba559c7023a86e5f8e97f026d511e48013987623915431c7ea9"},
+    {file = "ruff-0.1.11.tar.gz", hash = "sha256:f9d4d88cb6eeb4dfe20f9f0519bd2eaba8119bde87c3d5065c541dbae2b5a2cb"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,13 @@ python = "^3.9"
 requests = "^2.22"
 graphql-core = "^3.2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^5.2"
-black = "^22.3"
 requests-mock = "^1.9"
 types-requests = "^2.27"
-flake8 = "^4.0"
 pyfakefs = "^4.5"
-mypy = "0.961"
+mypy = "^1.8.0"
+ruff = "^0.1.11"
 
 [tool.poetry.scripts]
 qenerate = 'qenerate.cli:run'
@@ -30,10 +29,36 @@ qenerate = 'qenerate.cli:run'
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.black]
+[tool.ruff]
 line-length = 88
-target-version = ['py39']
-include = '^.*\.py$'
+target-version = 'py39'
+required-version = "0.1.11"
 
-[tool.flake8]
-max-line-length = 88
+src = ["qenerate"]
+extend-exclude = ["demo"]
+fix = true
+
+[tool.ruff.lint]
+preview = true
+
+# defaults are ["E4", "E7", "E9", "F"]
+extend-select = [
+    # flake8 default rules
+    "E1", # preview rule
+    "E2", # preview rule
+    "W",
+    # isort
+    "I",
+    # pylint
+    "PL",
+]
+ignore = [
+    "PLR0913", # Too many arguments
+    "PLR0917", # Too many positional arguments
+    "PLR6301", # Method `...` could be a function, class method, or static method
+]
+[tool.ruff.format]
+preview = true
+
+[tool.ruff.lint.isort]
+known-first-party = ["qenerate"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ target-version = 'py39'
 required-version = "0.1.11"
 
 src = ["qenerate"]
-extend-exclude = ["demo"]
+extend-exclude = ["demo", ".local"]
 fix = true
 
 [tool.ruff.lint]

--- a/qenerate/cli.py
+++ b/qenerate/cli.py
@@ -1,8 +1,8 @@
 import argparse
+
 import pkg_resources  # type: ignore
 
 from qenerate.core.code_command import CodeCommand
-
 from qenerate.core.introspection_command import IntrospectionCommand
 from qenerate.core.preprocessor import Preprocessor
 

--- a/qenerate/core/code_command.py
+++ b/qenerate/core/code_command.py
@@ -1,17 +1,17 @@
 import json
+import locale
 import os
 from pathlib import Path
 from typing import cast
 
-from graphql import build_client_schema, IntrospectionQuery, GraphQLSchema
+from graphql import GraphQLSchema, IntrospectionQuery, build_client_schema
 
+from qenerate.core.feature_flag_parser import FeatureFlagError
 from qenerate.core.plugin import GeneratedFile, Plugin
-from qenerate.core.preprocessor import GQLDefinitionType, Preprocessor, GQLDefinition
+from qenerate.core.preprocessor import GQLDefinition, GQLDefinitionType, Preprocessor
 from qenerate.plugins.pydantic_v1.plugin import (
     PydanticV1Plugin,
 )
-from qenerate.core.feature_flag_parser import FeatureFlagError
-
 
 plugins: dict[str, Plugin] = {
     "pydantic_v1": PydanticV1Plugin(),
@@ -52,7 +52,9 @@ class CodeCommand:
         return definitions
 
     def generate_code(self, introspection_file_path: str, dir: str):
-        with open(introspection_file_path) as f:
+        with open(
+            introspection_file_path, encoding=locale.getpreferredencoding(False)
+        ) as f:
             introspection = json.loads(f.read())["data"]
 
         schema = build_client_schema(cast(IntrospectionQuery, introspection))
@@ -78,7 +80,7 @@ class CodeCommand:
                 )
                 continue
 
-            if definition.kind in (GQLDefinitionType.QUERY, GQLDefinitionType.MUTATION):
+            if definition.kind in {GQLDefinitionType.QUERY, GQLDefinitionType.MUTATION}:
                 operations_by_plugin[definition.feature_flags.plugin].append(definition)
             elif definition.kind == GQLDefinitionType.FRAGMENT:
                 fragments_by_plugin[definition.feature_flags.plugin].append(definition)

--- a/qenerate/core/feature_flag_parser.py
+++ b/qenerate/core/feature_flag_parser.py
@@ -1,7 +1,7 @@
-from collections.abc import Mapping
-from enum import Enum
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
+from enum import Enum
 
 
 class NamingCollisionStrategy(Enum):

--- a/qenerate/core/introspection_command.py
+++ b/qenerate/core/introspection_command.py
@@ -1,6 +1,6 @@
 import json
-import requests
 
+import requests
 from graphql import get_introspection_query
 
 
@@ -9,7 +9,7 @@ class IntrospectionCommand:
     def introspection_query(url: str):
         query = get_introspection_query()
         request = requests.post(url, json={"query": query})
-        if request.status_code == 200:
+        if request.status_code == requests.codes.ok:
             print(json.dumps(request.json(), indent=4))
             return
         raise Exception(f"Could not query {url}")

--- a/qenerate/core/preprocessor.py
+++ b/qenerate/core/preprocessor.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
+
+import locale
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Iterable, Union
 
 from graphql import (
-    parse,
-    validate,
-    get_operation_ast,
-    visit,
-    Visitor,
-    OperationDefinitionNode,
-    OperationType,
     FragmentDefinitionNode,
     FragmentSpreadNode,
     GraphQLSchema,
+    OperationDefinitionNode,
+    OperationType,
+    Visitor,
+    get_operation_ast,
+    parse,
+    validate,
+    visit,
 )
 
 from qenerate.core.feature_flag_parser import FeatureFlagParser, FeatureFlags
@@ -150,7 +152,7 @@ class Preprocessor:
             raise error
 
     def process_file(self, file_path: Path) -> list[GQLDefinition]:
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding=locale.getpreferredencoding(False)) as f:
             content = f.read()
         feature_flags = FeatureFlagParser.parse(
             definition=content,

--- a/qenerate/core/unwrapper.py
+++ b/qenerate/core/unwrapper.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
 from enum import Enum
+
 from graphql import (
     GraphQLEnumType,
-    GraphQLOutputType,
-    GraphQLNonNull,
     GraphQLList,
+    GraphQLNonNull,
+    GraphQLOutputType,
     GraphQLScalarType,
 )
 

--- a/qenerate/plugins/pydantic_v1/mapper.py
+++ b/qenerate/plugins/pydantic_v1/mapper.py
@@ -1,5 +1,5 @@
-from collections.abc import Mapping
 import re
+from collections.abc import Mapping
 
 from graphql import GraphQLOutputType
 

--- a/qenerate/plugins/pydantic_v1/plugin.py
+++ b/qenerate/plugins/pydantic_v1/plugin.py
@@ -1,48 +1,49 @@
 from __future__ import annotations
-from typing import Mapping
-from functools import reduce
+
 import operator
+from functools import reduce
+from typing import Mapping
 
 from graphql import (
     FieldNode,
+    FragmentDefinitionNode,
+    FragmentSpreadNode,
     GraphQLOutputType,
     GraphQLScalarType,
     GraphQLSchema,
     InlineFragmentNode,
     OperationDefinitionNode,
-    FragmentDefinitionNode,
-    FragmentSpreadNode,
-    Visitor,
     TypeInfo,
     TypeInfoVisitor,
-    visit,
+    Visitor,
     parse,
+    visit,
 )
+
+from qenerate.core.feature_flag_parser import FeatureFlags, NamingCollisionStrategy
 from qenerate.core.plugin import (
     Fragment,
-    Plugin,
     GeneratedFile,
+    Plugin,
+)
+from qenerate.core.preprocessor import GQLDefinition, GQLDefinitionType
+from qenerate.core.unwrapper import Unwrapper, WrapperType
+from qenerate.plugins.pydantic_v1.mapper import (
+    graphql_class_name_str_to_python,
+    graphql_class_name_to_python,
+    graphql_field_name_to_python,
+    graphql_primitive_to_python,
 )
 from qenerate.plugins.pydantic_v1.typed_ast import (
+    BASE_CLASS_NAME,
+    ParsedClassNode,
+    ParsedFieldType,
     ParsedFragmentDefinitionNode,
     ParsedFragmentSpreadNode,
-    ParsedNode,
     ParsedInlineFragmentNode,
+    ParsedNode,
     ParsedOperationNode,
-    ParsedFieldType,
-    ParsedClassNode,
-    BASE_CLASS_NAME,
 )
-from qenerate.core.feature_flag_parser import NamingCollisionStrategy, FeatureFlags
-from qenerate.core.preprocessor import GQLDefinition, GQLDefinitionType
-
-from qenerate.plugins.pydantic_v1.mapper import (
-    graphql_class_name_to_python,
-    graphql_class_name_str_to_python,
-    graphql_primitive_to_python,
-    graphql_field_name_to_python,
-)
-from qenerate.core.unwrapper import Unwrapper, WrapperType
 
 INDENT = "    "
 
@@ -285,7 +286,7 @@ class FieldToTypeMatcherVisitor(Visitor):
                     self.feature_flags.collision_strategy
                     == NamingCollisionStrategy.ENUMERATE
                 ):
-                    if collision_enum_suffix == 2:
+                    if collision_enum_suffix == 2:  # noqa: PLR2004
                         class_name = f"{class_name}__{collision_enum_suffix}"
                     else:
                         idx = class_name.rfind("_") - 1

--- a/qenerate/plugins/pydantic_v1/typed_ast.py
+++ b/qenerate/plugins/pydantic_v1/typed_ast.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any, Optional
 
 from qenerate.core.preprocessor import GQLDefinitionType
-
 
 BASE_CLASS_NAME = "ConfiguredBaseModel"
 INDENT = "    "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import locale
 from pathlib import Path
 from typing import cast
 
@@ -13,32 +14,39 @@ def expected_files():
     """Read fixture files from tests/definitions/expected/PLUGIN/CASE and remove .txt suffix."""
 
     def _(plugin: str, case: str) -> list[GeneratedFile]:
-        return sorted(
-            [
-                GeneratedFile(file=f.with_suffix(""), content=f.read_text())
-                for f in Path(f"tests/generator/expected/{plugin}/{case}").glob("**/*")
-            ]
-        )
+        return sorted([
+            GeneratedFile(file=f.with_suffix(""), content=f.read_text())
+            for f in Path(f"tests/generator/expected/{plugin}/{case}").glob("**/*")
+        ])
 
     return _
 
 
 @pytest.fixture()
 def app_interface_schema():
-    with open("tests/generator/introspection-app-interface.json") as f:
+    with open(
+        "tests/generator/introspection-app-interface.json",
+        encoding=locale.getpreferredencoding(False),
+    ) as f:
         raw_schema = json.loads(f.read())["data"]
     return build_client_schema(cast(IntrospectionQuery, raw_schema))
 
 
 @pytest.fixture()
 def app_interface_2023_03_schema():
-    with open("tests/generator/introspection-app-interface_2023_03.json") as f:
+    with open(
+        "tests/generator/introspection-app-interface_2023_03.json",
+        encoding=locale.getpreferredencoding(False),
+    ) as f:
         raw_schema = json.loads(f.read())["data"]
     return build_client_schema(cast(IntrospectionQuery, raw_schema))
 
 
 @pytest.fixture()
 def github_schema():
-    with open("tests/generator/introspection-github.json") as f:
+    with open(
+        "tests/generator/introspection-github.json",
+        encoding=locale.getpreferredencoding(False),
+    ) as f:
         raw_schema = json.loads(f.read())["data"]
     return build_client_schema(cast(IntrospectionQuery, raw_schema))

--- a/tests/core/test_code_command.py
+++ b/tests/core/test_code_command.py
@@ -3,12 +3,11 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from graphql import GraphQLSchema
-from qenerate.core.feature_flag_parser import FeatureFlags
 
-from qenerate.core.plugin import Fragment, Plugin, GeneratedFile
 from qenerate.core.code_command import CodeCommand
+from qenerate.core.feature_flag_parser import FeatureFlags
+from qenerate.core.plugin import Fragment, GeneratedFile, Plugin
 from qenerate.core.preprocessor import GQLDefinition, GQLDefinitionType, Preprocessor
-
 
 SCHEMA_DIR = "tests/generator"
 APP_INTERFACE_INTROSPECTION = "introspection-app-interface.json"

--- a/tests/core/test_feature_flags.py
+++ b/tests/core/test_feature_flags.py
@@ -1,9 +1,10 @@
 import pytest
+
 from qenerate.core.feature_flag_parser import (
-    NamingCollisionStrategy,
     FeatureFlagError,
-    FeatureFlags,
     FeatureFlagParser,
+    FeatureFlags,
+    NamingCollisionStrategy,
 )
 
 

--- a/tests/core/test_introspection_command.py
+++ b/tests/core/test_introspection_command.py
@@ -1,8 +1,8 @@
 from json import JSONDecodeError
+
 from pytest import raises
 
 from qenerate.core.introspection_command import IntrospectionCommand
-
 
 TEST_URL = "http://my-url.zzzzz"
 

--- a/tests/core/test_preprocessor.py
+++ b/tests/core/test_preprocessor.py
@@ -1,16 +1,16 @@
 from pathlib import Path
 from typing import Iterable
-import pytest
 
+import pytest
 from graphql import GraphQLError, GraphQLSyntaxError
 
+from qenerate.core.feature_flag_parser import FeatureFlags
 from qenerate.core.preprocessor import (
     AnonymousOperationError,
     GQLDefinition,
     GQLDefinitionType,
     Preprocessor,
 )
-from qenerate.core.feature_flag_parser import FeatureFlags
 
 
 def normalize_definition(definition: str) -> str:

--- a/tests/core/test_unwrapper.py
+++ b/tests/core/test_unwrapper.py
@@ -1,15 +1,14 @@
 import pytest
-
-from qenerate.core.unwrapper import Unwrapper, UnwrapperResult, WrapperType
-
 from graphql import (
     GraphQLEnumType,
+    GraphQLList,
+    GraphQLNonNull,
+    GraphQLObjectType,
     GraphQLOutputType,
     GraphQLScalarType,
-    GraphQLNonNull,
-    GraphQLList,
-    GraphQLObjectType,
 )
+
+from qenerate.core.unwrapper import Unwrapper, UnwrapperResult, WrapperType
 
 
 @pytest.mark.parametrize(

--- a/tests/plugins/test_generate.py
+++ b/tests/plugins/test_generate.py
@@ -1,8 +1,11 @@
+import locale
 from enum import Enum
 from pathlib import Path
+
 import pytest
+
 from qenerate.core.code_command import plugins
-from qenerate.core.feature_flag_parser import NamingCollisionStrategy, FeatureFlags
+from qenerate.core.feature_flag_parser import FeatureFlags, NamingCollisionStrategy
 from qenerate.core.plugin import GeneratedFile
 from qenerate.core.preprocessor import GQLDefinition, GQLDefinitionType
 
@@ -151,7 +154,7 @@ def test_rendering(
     operation_definitions = []
     for source_file in Path(f"tests/generator/definitions/{case}").glob("**/*"):
         file_id = source_file.with_suffix("").name
-        with open(source_file, "r") as f:
+        with open(source_file, "r", encoding=locale.getpreferredencoding(False)) as f:
             content = f.read()
         kind = type_map[file_id]
         collision_strategy = collision_strategies.get(


### PR DESCRIPTION
Replace `black`, `isort`, and `flake8` with `ruff`.