### PR TITLE
fix: handle unsupported directive locations in introspection data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Qenerate Changelog
 
+## 0.9.2
+
+Fixes:
+
+* Handle unsupported directive locations (e.g. `DIRECTIVE_DEFINITION`) in
+  introspection data from newer graphql-js versions (>= 16.14.0) that are not
+  yet supported by graphql-core (Python).
+
 ## 0.9.1
 
 Chore:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qenerate"
-version = "0.9.1"
+version = "0.9.2"
 requires-python = ">=3.12"
 description = "Code Generator for GraphQL Query and Fragment Data Classes"
 readme = "README.md"

--- a/qenerate/core/code_command.py
+++ b/qenerate/core/code_command.py
@@ -1,9 +1,10 @@
 import json
 import os
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 from graphql import GraphQLSchema, IntrospectionQuery, build_client_schema
+from graphql.language import DirectiveLocation
 
 from qenerate.core.feature_flag_parser import FeatureFlagError
 from qenerate.core.plugin import GeneratedFile, Plugin
@@ -48,10 +49,34 @@ class CodeCommand:
         )
         return definitions
 
+    @staticmethod
+    def sanitize_introspection(introspection: dict[str, Any]) -> dict[str, Any]:
+        """Strip directive locations unknown to graphql-core.
+
+        graphql-js 16.14.0 added DIRECTIVE_DEFINITION to the DirectiveLocation
+        enum, but graphql-core (Python) does not support it yet (as of 3.2.x /
+        3.3.0-alpha). build_client_schema() raises a TypeError when it
+        encounters an unknown location.
+
+        This workaround filters unsupported locations from the introspection
+        data so qenerate can continue to work with newer GraphQL servers.
+
+        TODO: Remove once graphql-core supports DIRECTIVE_DEFINITION
+        (track https://github.com/graphql-python/graphql-core/issues).
+        """
+        valid_locations = {loc.name for loc in DirectiveLocation}
+        for directive in introspection.get("__schema", {}).get("directives", []):
+            original = directive.get("locations", [])
+            filtered = [loc for loc in original if loc in valid_locations]
+            if len(filtered) < len(original):
+                directive["locations"] = filtered
+        return introspection
+
     def generate_code(self, introspection_file_path: str, directory: str) -> None:
         introspection = json.loads(
             Path(introspection_file_path).read_text(encoding="utf-8")
         )["data"]
+        introspection = self.sanitize_introspection(introspection)
 
         schema = build_client_schema(cast("IntrospectionQuery", introspection))
 

--- a/tests/core/test_code_command.py
+++ b/tests/core/test_code_command.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
 from graphql import GraphQLSchema
 from pyfakefs.fake_filesystem_unittest import FakeFilesystem
 
@@ -131,3 +132,46 @@ def test_dir_tree_with_different_operations(fs: FakeFilesystem) -> None:
     assert os.path.exists("/tmp/my_query.py")
     assert os.path.exists("/tmp/sub/my_query.py")
     assert os.path.exists("/tmp/sub/my_mutation.py")
+
+
+@pytest.mark.parametrize(
+    ("locations", "expected"),
+    [
+        pytest.param(
+            ["FIELD_DEFINITION", "ENUM_VALUE"],
+            ["FIELD_DEFINITION", "ENUM_VALUE"],
+            id="all-valid",
+        ),
+        pytest.param(
+            ["FIELD_DEFINITION", "DIRECTIVE_DEFINITION", "ENUM_VALUE"],
+            ["FIELD_DEFINITION", "ENUM_VALUE"],
+            id="strips-unsupported",
+        ),
+        pytest.param(
+            ["DIRECTIVE_DEFINITION"],
+            [],
+            id="all-unsupported",
+        ),
+        pytest.param(
+            [],
+            [],
+            id="empty-locations",
+        ),
+    ],
+)
+def test_sanitize_introspection(locations: list[str], expected: list[str]) -> None:
+    introspection: dict = {
+        "__schema": {
+            "directives": [
+                {"name": "deprecated", "locations": locations},
+            ],
+        },
+    }
+    result = CodeCommand.sanitize_introspection(introspection)
+    assert result["__schema"]["directives"][0]["locations"] == expected
+
+
+def test_sanitize_introspection_no_directives() -> None:
+    introspection: dict = {"__schema": {}}
+    result = CodeCommand.sanitize_introspection(introspection)
+    assert result == {"__schema": {}}

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "qenerate"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "graphql-core" },
@@ -373,7 +373,7 @@ dev = [
 
 [[package]]
 name = "requests"
-version = "2.34.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -381,9 +381,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/36/7180e7f077c38108945dbbdf60fe04db681c3feb6e96419f8c6dc8723741/requests-2.34.1.tar.gz", hash = "sha256:0fc5669f2b69704449fe1552360bd2a73a54512dfd03e65529157f1513322beb", size = 142783, upload-time = "2026-05-13T19:20:24.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/5a/4a949d170476de3c04ac036b5466422fbcbf348a917d8042eedf2cac7d1b/requests-2.34.1-py3-none-any.whl", hash = "sha256:bf38a3ff993960d3dd819c08862c40b3c703306eb7c744fcd9f4ddbb95b548f0", size = 73085, upload-time = "2026-05-13T19:20:22.827Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- graphql-js 16.14.0 added `DIRECTIVE_DEFINITION` to the `DirectiveLocation` enum, but graphql-core (Python) does not support it yet (as of 3.2.x / 3.3.0-alpha)
- This caused `build_client_schema()` to raise a `TypeError` when processing introspection data from newer GraphQL servers (e.g. qontract-server after graphql-js lock file update)
- Strips unsupported directive locations from introspection data before building the schema

## Test plan

- [x] Parametrized unit tests for `sanitize_introspection()` covering: all valid, mixed, all unsupported, empty locations, and missing directives key
- [x] All 52 tests pass
- [x] ruff, mypy pass