### PR TITLE
fix: stop hardcoding DIRECTIVE_DEFINITION as unsupported in sanitize_introspection tests

### DIFF
--- a/tests/core/test_code_command.py
+++ b/tests/core/test_code_command.py
@@ -146,12 +146,12 @@ def test_dir_tree_with_different_operations(fs: FakeFilesystem) -> None:
             id="all-valid",
         ),
         pytest.param(
-            ["FIELD_DEFINITION", "DIRECTIVE_DEFINITION", "ENUM_VALUE"],
+            ["FIELD_DEFINITION", "NOT_YET_SUPPORTED_LOCATION", "ENUM_VALUE"],
             ["FIELD_DEFINITION", "ENUM_VALUE"],
             id="strips-unsupported",
         ),
         pytest.param(
-            ["DIRECTIVE_DEFINITION"],
+            ["NOT_YET_SUPPORTED_LOCATION"],
             [],
             id="all-unsupported",
         ),


### PR DESCRIPTION
## Summary

- `graphql-core` 3.2.11 added support for the `DIRECTIVE_DEFINITION` directive location, which `test_sanitize_introspection` assumed would always be stripped by `CodeCommand.sanitize_introspection()` (added in #549 as a workaround for graphql-core lacking that location at the time).
- This currently breaks #588 (Renovate lock file maintenance bumping `graphql-core` to 3.2.11), tracked in [APPSRE-14361](https://redhat.atlassian.net/browse/APPSRE-14361).
- Replaces the hardcoded `DIRECTIVE_DEFINITION` in the test parametrization with a synthetic `NOT_YET_SUPPORTED_LOCATION` string that can never become a valid `DirectiveLocation`. This verifies the actual filtering behavior without depending on which real GraphQL spec locations `graphql-core` happens to support at any given version — so it won't regress on future `graphql-core` bumps.

## Test plan

- [x] `pytest` — 52/52 pass (verified against both `graphql-core` 3.2.9, current `main`, and 3.2.11, PR #588's bumped version)
- [x] `ruff check` — clean
- [x] `mypy` — clean